### PR TITLE
Improve agent thread join handling in main

### DIFF
--- a/main.py
+++ b/main.py
@@ -179,7 +179,16 @@ def main() -> None:
 
     signal.signal(signal.SIGINT, partial(cleanup, swarm))  # handler for Ctrl+C
 
-    agent_thread.join()
+    try:
+        # Wait for the agent thread to complete
+        while agent_thread.is_alive():
+            agent_thread.join(timeout=5)  # Check every 5 second
+    except KeyboardInterrupt:
+        logger.info("KeyboardInterrupt received in main thread")
+        cleanup(swarm, signal.SIGINT, None)
+    except Exception as e:
+        logger.error(f"Unexpected error in main thread: {e}")
+        cleanup(swarm, None, None)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Replaces a blocking join with a loop that checks the agent thread's status every 5 seconds. Adds exception handling for KeyboardInterrupt and other exceptions to ensure proper cleanup and logging.

Related: [Python SIGINT not caught](https://stackoverflow.com/a/29661280)