### PR TITLE
Add support for custom OpenAI base URL

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -15,7 +15,8 @@ PORT=443
 WDM_LOG=0
 
 # use for LLM agents
-OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_API_KEY=your_openai_compatible_api_key_here
+OPENAI_BASE_URL=your_openai_compatible_base_url_here
 
 # ARC-AGI-3 API Key
 ARC_API_KEY=your_arc_api_key_here

--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -59,7 +59,7 @@ class LLM(Agent):
         logging.getLogger("openai").setLevel(logging.CRITICAL)
         logging.getLogger("httpx").setLevel(logging.CRITICAL)
 
-        client = OpenAIClient(api_key=os.environ.get("OPENAI_API_KEY", ""))
+        client = OpenAIClient(api_key=os.environ.get("OPENAI_API_KEY", ""), base_url=os.environ.get("OPENAI_BASE_URL", ""))
 
         functions = self.build_functions()
         tools = self.build_tools()


### PR DESCRIPTION
Updated .env-example to include OPENAI_BASE_URL for OpenAI-compatible endpoints. Modified LLM agent to use the base_url from environment variables, enabling support for custom or self-hosted OpenAI-compatible APIs.