### PR TITLE
Sanitize model name in LLM agent name property

### DIFF
--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -36,7 +36,8 @@ class LLM(Agent):
     @property
     def name(self) -> str:
         obs = "with-observe" if self.DO_OBSERVATION else "no-observe"
-        name = f"{super().name}.{self.MODEL}.{obs}"
+        sanitized_model_name = self.MODEL.replace('/', '-').replace(':', '-')
+        name = f"{super().name}.{sanitized_model_name}.{obs}"
         if self.REASONING_EFFORT:
             name += f".{self.REASONING_EFFORT}"
         return name


### PR DESCRIPTION
Replaces '/' and ':' characters in the model name with '-' when constructing the LLM agent's name property to ensure compatibility and avoid invalid characters.