### PR TITLE
Set MODEL_REQUIRES_TOOLS to True in LLM agent

### DIFF
--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -19,7 +19,7 @@ class LLM(Agent):
     MAX_ACTIONS: int = 80
     DO_OBSERVATION: bool = True
     REASONING_EFFORT: Optional[str] = None
-    MODEL_REQUIRES_TOOLS: bool = False
+    MODEL_REQUIRES_TOOLS: bool = True
 
     MESSAGE_LIMIT: int = 10
     MODEL: str = "gpt-4o-mini"


### PR DESCRIPTION
Changed the default value of MODEL_REQUIRES_TOOLS from False to True in the LLM agent template. This ensures that the model is now expected to require tools by default.

Related #26 