### PR TITLE
Log messages to file on BadRequestError

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 recordings/*.recording.jsonl
 tests/recordings/*.recording.jsonl
 tests/recordings/not-a-recording.txt
+messages.json

--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -122,7 +122,9 @@ class LLM(Agent):
                     create_kwargs["reasoning_effort"] = self.REASONING_EFFORT
                 response = client.chat.completions.create(**create_kwargs)
             except openai.BadRequestError as e:
-                logger.info(f"Message dump: {self.messages}")
+                logger.info(f"Messages saved to messages.json")
+                with open("messages.json", "w") as f:
+                    json.dump(self.messages, f, indent=2)
                 raise e
             self.track_tokens(
                 response.usage.total_tokens, response.choices[0].message.content
@@ -156,7 +158,9 @@ class LLM(Agent):
                     create_kwargs["reasoning_effort"] = self.REASONING_EFFORT
                 response = client.chat.completions.create(**create_kwargs)
             except openai.BadRequestError as e:
-                logger.info(f"Message dump: {self.messages}")
+                logger.info(f"Messages saved to messages.json")
+                with open("messages.json", "w") as f:
+                    json.dump(self.messages, f, indent=2)
                 raise e
             self.track_tokens(response.usage.total_tokens)
             message5 = response.choices[0].message
@@ -194,7 +198,9 @@ class LLM(Agent):
                     create_kwargs["reasoning_effort"] = self.REASONING_EFFORT
                 response = client.chat.completions.create(**create_kwargs)
             except openai.BadRequestError as e:
-                logger.info(f"Message dump: {self.messages}")
+                logger.info(f"Messages saved to messages.json")
+                with open("messages.json", "w") as f:
+                    json.dump(self.messages, f, indent=2)
                 raise e
             self.track_tokens(response.usage.total_tokens)
             message5 = response.choices[0].message


### PR DESCRIPTION
Replaces logger.info calls with writing self.messages to a messages.json file when an openai.BadRequestError occurs. This change aids in debugging by preserving the message history for further analysis.