### PR TITLE
Fixing Issue with Scorecard Not Being Found

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -3,11 +3,14 @@ import logging
 import os
 import time
 from abc import ABC, abstractmethod
+from copy import deepcopy
 from typing import Any, Optional
 
 import requests
+import requests.cookies
 from pydantic import ValidationError
 from requests import Response
+from requests.cookies import RequestsCookieJar
 
 from .recorder import Recorder
 from .structs import FrameData, GameAction, GameState, Scorecard
@@ -47,6 +50,7 @@ class Agent(ABC):
         ROOT_URL: str,
         record: bool,
         tags: Optional[list[str]] = None,
+        cookies: requests.cookies.RequestsCookieJar = RequestsCookieJar(),
     ) -> None:
         self.ROOT_URL = ROOT_URL
         self.card_id = card_id
@@ -64,6 +68,7 @@ class Agent(ABC):
         }
         # Reuse session
         self._session = requests.Session()
+        self._session.cookies = deepcopy(cookies)
         self._session.headers.update(self.headers)
 
     @trace_agent_session

--- a/agents/swarm.py
+++ b/agents/swarm.py
@@ -81,6 +81,7 @@ class Swarm:
                 agent_name=self.agent_name,
                 ROOT_URL=self.ROOT_URL,
                 record=True,
+                cookies=self._session.cookies,
                 tags=self.tags,
             )
             self.agents.append(a)


### PR DESCRIPTION
Resolves #19 #29

Root Cause: ALB + Sticky Sessions + Agents getting a fresh session.  This was almost always reproducing with a Random Agent at a single step, Here is why.

Open Scorecard -> SS Points to S1
Agent New Session -> no cookie likely picks S2 (Sad Path), might pick ups S1 (Everything's fine) Close Scorecard -> Cookie points to S2, No Scorecard Found

Solution:  Have the open scardcard cookie be injected into the agent(s) so they will always be directed to where the open scardcard request was served.

Stateful systems are fun!