### PR TITLE
Update default zone_size in grid image generation

### DIFF
--- a/agents/templates/reasoning_agent.py
+++ b/agents/templates/reasoning_agent.py
@@ -63,7 +63,7 @@ class ReasoningAgent(ReasoningLLM):
         self.screen_history = []
 
     def generate_grid_image_with_zone(
-        self, grid: List[List[int]], cell_size: int = 40, zone_size: int = 20
+        self, grid: List[List[int]], cell_size: int = 40, zone_size: int = 16
     ) -> bytes:
         """Generate PIL image of the grid with colored cells and zone coordinates."""
         if not grid or not grid[0]:

--- a/agents/templates/reasoning_agent.py
+++ b/agents/templates/reasoning_agent.py
@@ -49,6 +49,7 @@ class ReasoningAgent(ReasoningLLM):
     MODEL = "o4-mini"
     MESSAGE_LIMIT = 5
     REASONING_EFFORT = "high"
+    ZONE_SIZE = 16
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -63,7 +64,7 @@ class ReasoningAgent(ReasoningLLM):
         self.screen_history = []
 
     def generate_grid_image_with_zone(
-        self, grid: List[List[int]], cell_size: int = 40, zone_size: int = 16
+        self, grid: List[List[int]], cell_size: int = 40
     ) -> bytes:
         """Generate PIL image of the grid with colored cells and zone coordinates."""
         if not grid or not grid[0]:
@@ -119,8 +120,8 @@ class ReasoningAgent(ReasoningLLM):
                 )
 
         # Draw zone coordinates and borders
-        for y in range(0, height, zone_size):
-            for x in range(0, width, zone_size):
+        for y in range(0, height, self.ZONE_SIZE):
+            for x in range(0, width, self.ZONE_SIZE):
                 # Draw zone coordinate label
                 try:
                     font = ImageFont.load_default()
@@ -137,8 +138,8 @@ class ReasoningAgent(ReasoningLLM):
                     logger.error(f"Failed to draw zone label at ({x},{y}): {e}")
 
                 # Draw zone boundary
-                zone_width = min(zone_size, width - x) * cell_size
-                zone_height = min(zone_size, height - y) * cell_size
+                zone_width = min(self.ZONE_SIZE, width - x) * cell_size
+                zone_height = min(self.ZONE_SIZE, height - y) * cell_size
                 draw.rectangle(
                     [
                         x * cell_size,


### PR DESCRIPTION
Changed the default value of the zone_size parameter from 20 to 16 in the generate_grid_image_with_zone method to better match expected grid rendering requirements.

Old one: 
<img width="754" height="764" alt="image" src="https://github.com/user-attachments/assets/97f9f296-ab9e-4ec5-80ae-809c4f31a6a5" />

https://github.com/arcprize/ARC-AGI-3-Agents/pull/30#issuecomment-3094398065