### PR TITLE
Update llm_agents.py to have correct directional indicators?

### DIFF
--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -273,22 +273,22 @@ class LLM(Agent):
             },
             {
                 "name": GameAction.ACTION1.name,
-                "description": "Send this simple input action (1, A, Left).",
+                "description": "Send this simple input action (1, W, Up).",
                 "parameters": empty_params,
             },
             {
                 "name": GameAction.ACTION2.name,
-                "description": "Send this simple input action (2, D, Right).",
+                "description": "Send this simple input action (2, S, Down).",
                 "parameters": empty_params,
             },
             {
                 "name": GameAction.ACTION3.name,
-                "description": "Send this simple input action (3, W, Up).",
+                "description": "Send this simple input action (3, A, Left).",
                 "parameters": empty_params,
             },
             {
                 "name": GameAction.ACTION4.name,
-                "description": "Send this simple input action (4, S, Down).",
+                "description": "Send this simple input action (4, D, Right).",
                 "parameters": empty_params,
             },
             {
@@ -577,7 +577,7 @@ Grids. Each Grid is a matrix size INT<0,63> by INT<0,63> filled with
 INT<0,15> values.
 
 You are playing a game called LockSmith. Rules and strategy:
-* RESET: start over, ACTION1: move left, ACTION2: move right, ACTION3: move up, ACTION4: move down (ACTION5 and ACTION6 do nothing in this game)
+* RESET: start over, ACTION1: move up, ACTION2: move down, ACTION3: move left, ACTION4: move right (ACTION5 and ACTION6 do nothing in this game)
 * you may may one action per turn
 * your goal is find and collect a matching key then touch the exit door
 * 6 levels total, score shows which level, complete all levels to win (grid row 62)


### PR DESCRIPTION
I noticed that the action definitions that the agents were receiving were slightly incorrect.  It was being told that Action1 was LEFT when in fact, it is UP.  ```ACTION1: move up, ACTION2: move down, ACTION3: move left, ACTION4: move right```  I only noticed this because I cheated and explicitly told my agent to go left once and then move up four times to beat the first level. (I wanted to make it on the leaderboard!) When I watched the replays I noticed it couldn't even follow that simple instruction.  So I did a bit of digging and saw that there seemed to be a disconnect in what I was seeing Action1 as in the WebUI and what we were telling it Action1 was in the prompt.  Hope this helps?
