### PR TITLE
Fix grid selection in `define_next_action` method

### DIFF
--- a/agents/templates/reasoning_agent.py
+++ b/agents/templates/reasoning_agent.py
@@ -279,7 +279,7 @@ Hint:
     def define_next_action(self, latest_frame: FrameData) -> ReasoningActionResponse:
         """Define next action for the reasoning agent."""
         # Generate map image
-        current_grid = latest_frame.frame[0] if latest_frame.frame else []
+        current_grid = latest_frame.frame[-1] if latest_frame.frame else []
         map_image = self.generate_grid_image_with_zone(current_grid)
 
         # Build messages


### PR DESCRIPTION
Changed the grid selection from the first to the last frame in the list when generating the map image. This ensures the agent uses the most recent frame data for reasoning.

After a level is solved, two grids are returned. 

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/65db2d1c-e405-46af-ac7a-a630d38924f5" />


first grid - old level
second grid - new level

currently the script uses old level, so, the agent didn't know it solved the level.

<img width="2560" height="1600" alt="image" src="https://github.com/user-attachments/assets/2b1f20e8-9aca-4b18-84e2-6347b6c69783" />

---


