### PR TITLE
fix pillow typing issue

### DIFF
--- a/agents/templates/langgraph_thinking/vision.py
+++ b/agents/templates/langgraph_thinking/vision.py
@@ -222,7 +222,7 @@ def render_frame(
 
 def add_highlight(
     draw: ImageDraw.ImageDraw,
-    coords: ImageDraw.Coords,
+    coords: tuple[tuple[int, int], tuple[int, int]],
     label: str,
 ) -> None:
     (x1, y1), (x2, y2) = coords


### PR DESCRIPTION
Running `uv run main.py` with Pillow 12.0.0 will lead to the following error: `AttributeError: module 'PIL.ImageDraw' has no attribute 'Coords'`.

Proposed fix:

Replace `coords: ImageDraw.Coords` with `coords: tuple[tuple[int, int], tuple[int, int]]` in the `add_highlight` function in `ARC-AGI-3-Agents/agents/templates/langgraph_thinking/vision.py`