### PR TITLE
fix: update FrameData.score to levels_completed and fix default API e…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ RECORDINGS_DIR=recordings
 
 # define the server
 SCHEME=https
-HOST=sandbox.internal.arc-prize.com
+HOST=three.arcprize.org
 PORT=443
 
 # ARG-AGI Controls

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -55,7 +55,7 @@ class Agent(ABC):
         self.guid = ""
         self.agent_name = agent_name
         self.tags = tags or []
-        self.frames = [FrameData(score=0)]
+        self.frames = [FrameData(levels_completed=0)]
         self._cleanup = True
         if record:
             self.start_recording()

--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -353,7 +353,7 @@ class LLM(Agent):
 Reply with a few sentences of plain-text strategy observation about the frame to inform your next action.
         """.format(
                 latest_frame=self.pretty_print_3d(latest_frame.frame),
-                score=latest_frame.score,
+                score=latest_frame.levels_completed,
                 state=latest_frame.state.name,
             )
         )
@@ -428,7 +428,7 @@ class ReasoningLLM(LLM, Agent):
             "reasoning_tokens": self._last_reasoning_tokens,
             "total_reasoning_tokens": self._total_reasoning_tokens,
             "game_context": {
-                "score": latest_frame.score,
+                "score": latest_frame.levels_completed,
                 "state": latest_frame.state.name,
                 "action_counter": self.action_counter,
                 "frame_count": len(frames),
@@ -524,7 +524,7 @@ class GuidedLLM(LLM, Agent):
             "reasoning_tokens": self._last_reasoning_tokens,
             "total_reasoning_tokens": self._total_reasoning_tokens,
             "game_context": {
-                "score": latest_frame.score,
+                "score": latest_frame.levels_completed,
                 "state": latest_frame.state.name,
                 "action_counter": self.action_counter,
                 "frame_count": len(frames),


### PR DESCRIPTION
This PR fixes two issues that prevent LLM agents from running:

1. FrameData attribute rename (arcengine v0.9.3 breaking change):
   - Changed `FrameData(score=0)` to `FrameData(levels_completed=0)` in agent.py
   - Changed `latest_frame.score` to `latest_frame.levels_completed` in llm_agents.py
   - Fixes: AttributeError: 'FrameData' object has no attribute 'score'

2. Default API endpoint misconfiguration:
   - Changed HOST from `sandbox.internal.arc-prize.com` to `three.arcprize.org`
   - The sandbox endpoint returns 502 errors for public users
   - Fixes: API request failed with status 502