### PR TITLE
Fix issue `action.reasoning` is not stored.

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -135,7 +135,7 @@ class Agent(ABC):
         raw = self.arc_env.step(
             action,
             data=data,
-            reasoning=data["reasoning"] if "reasoning" in data else {},
+            reasoning=action.reasoning,
         )
         return self._convert_raw_frame_data(raw)
 


### PR DESCRIPTION
This PR fixes an issue where reasoning was not being persisted by passing `action.reasoning` directly in `do_action_request()` instead of reading from `data["reasoning"]`.

### Before
<img width="1422" height="786" alt="image" src="https://github.com/user-attachments/assets/e553b4ff-46d8-4c79-a6e3-ef23564e0eb1" />

### After
<img width="1401" height="786" alt="image" src="https://github.com/user-attachments/assets/245456d7-9d2f-4cdd-a8eb-d2a3aa566ce5" />

