### PR TITLE
Replace three.arcprize.org with arcprize.org

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,11 @@ RECORDINGS_DIR=recordings
 
 # define the server
 SCHEME=https
-HOST=three.arcprize.org
+HOST=arcprize.org
 PORT=443
 
 # ARG-AGI Controls
-ARC_BASE_URL=https://three.arcprize.org/
+ARC_BASE_URL=https://arcprize.org/
 OPERATION_MODE=online
 RECORDINGS_DIR=recordings
 ENVIRONMENTS_DIR=environment_files

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd ARC-AGI-3-Agents
 cp .env.example .env
 ```
 
-3. Get an API key from the [ARC-AGI-3 Website](https://three.arcprize.org/) and set it as an environment variable in your .env file.
+3. Get an API key from the [ARC-AGI-3 Website](https://arcprize.org/platform) and set it as an environment variable in your .env file.
 
 ```bash
 export ARC_API_KEY="your_api_key_here"
@@ -29,7 +29,7 @@ export ARC_API_KEY="your_api_key_here"
 uv run main.py --agent=random --game=ls20
 ```
 
-For more information, see the [documentation](https://three.arcprize.org/docs#quick-start) or the [tutorial video](https://youtu.be/xEVg9dcJMkw).
+For more information, see the [documentation](https://arcprize.org/docs#quick-start) or the [tutorial video](https://youtu.be/xEVg9dcJMkw).
 
 ## Changelog
 ## [0.9.3] - 2026-01-29
@@ -130,7 +130,7 @@ To run the tests, you will need to have `pytest` installed. Run the tests like t
 pytest
 ```
 
-For more information on tests, please see the [tests documentation](https://three.arcprize.org/docs#testing).
+For more information on tests, please see the [tests documentation](https://arcprize.org/docs#testing).
 
 ## License
 

--- a/agents/README.md
+++ b/agents/README.md
@@ -1,3 +1,3 @@
 # ARC-AGI-3 Agents
 
-For all information on how to build, test, and run agents, as well as the technical specifications of the agent and game APIs, please see the [agents documentation](https://three.arcprize.org/docs#agent-quickstart).
+For all information on how to build, test, and run agents, as well as the technical specifications of the agent and game APIs, please see the [agents documentation](https://arcprize.org/docs#agent-quickstart).

--- a/agents/templates/README.md
+++ b/agents/templates/README.md
@@ -2,5 +2,5 @@
 
 For all information on how to build agents from templates, please see the official documentation:
 
-- Standard templates: [Building Agents](https://three.arcprize.org/docs#building-agents)
-- Third-party templates: [Third-Party Templates](https://three.arcprize.org/docs#third-party-templates)
+- Standard templates: [Building Agents](https://arcprize.org/docs#building-agents)
+- Third-party templates: [Third-Party Templates](https://arcprize.org/docs#third-party-templates)

--- a/llms.txt
+++ b/llms.txt
@@ -17,7 +17,7 @@ cd ARC-AGI-3-Agents
 cp .env-example .env
 ```
 
-3. Get an API key from the [ARC-AGI-3 website](https://three.arcprize.org/) and set it in `.env` (or export it):
+3. Get an API key from the [ARC-AGI-3 website](https://arcprize.org/) and set it in `.env` (or export it):
 
 ```bash
 export ARC_API_KEY="your_api_key_here"
@@ -29,7 +29,7 @@ export ARC_API_KEY="your_api_key_here"
 uv run main.py --agent=random --game=locksmith
 ```
 
-For more details see the full docs at <https://three.arcprize.org/docs>.
+For more details see the full docs at <https://arcprize.org/docs>.
 
 ---
 
@@ -85,7 +85,7 @@ Run the Python test-suite with `pytest`:
 pytest
 ```
 
-See <https://three.arcprize.org/docs#testing> for more info.
+See <https://arcprize.org/docs#testing> for more info.
 
 ---
 
@@ -98,7 +98,7 @@ The core agent framework lives in [`agents/`](https://github.com/arcprize/ARC-AG
 - `recorder.py` – JSONL gameplay recording utilities.
 - `structs.py` – typed data structures (`FrameData`, `GameAction`, etc.).
 
-See the concise README in that folder or jump straight to the online docs → [Agent Quick-Start](https://three.arcprize.org/docs#agent-quickstart).
+See the concise README in that folder or jump straight to the online docs → [Agent Quick-Start](https://arcprize.org/docs#agent-quickstart).
 
 ## Agent Templates
 
@@ -108,8 +108,8 @@ Ready-made templates live in [`agents/templates/`](https://github.com/arcprize/A
 • **Third-party integrations** – HuggingFace *smolagents*, AgentOps tracing & reasoning agent, LangChain/LangGraph agents.
 
 Browse them on GitHub or read the docs:
-- Standard templates: <https://three.arcprize.org/docs#building-agents>
-- Third-party templates: <https://three.arcprize.org/docs#third-party-templates>
+- Standard templates: <https://arcprize.org/docs#building-agents>
+- Third-party templates: <https://arcprize.org/docs#third-party-templates>
 
 ---
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -6,4 +6,4 @@ To run the tests, you will need to have `pytest` installed. Run the tests like t
 pytest
 ```
 
-For more information on tests, please see the [tests documentation](https://three.arcprize.org/docs#testing).
+For more information on tests, please see the [tests documentation](https://arcprize.org/docs#testing).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,6 +67,6 @@ def use_env_vars(monkeypatch):
     if not os.environ.get("SCHEME"):
         monkeypatch.setenv("SCHEME", "https")
     if not os.environ.get("HOST"):
-        monkeypatch.setenv("HOST", "three.arcprize.org")
+        monkeypatch.setenv("HOST", "arcprize.org")
     if not os.environ.get("PORT"):
         monkeypatch.setenv("PORT", "443")


### PR DESCRIPTION
- Replace all occurrences of 'three.arcprize.org' with 'arcprize.org'
- Fix README.md to point to https://arcprize.org/platform for obtaining an API key