### PR TITLE
fix: properly pass action reasoning to environment

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -132,10 +132,11 @@ class Agent(ABC):
 
     def do_action_request(self, action: GameAction) -> FrameData:
         data = action.action_data.model_dump()
+        reasoning = getattr(action, "reasoning", data.get("reasoning", {}))
         raw = self.arc_env.step(
             action,
             data=data,
-            reasoning=data["reasoning"] if "reasoning" in data else {},
+            reasoning=reasoning,
         )
         return self._convert_raw_frame_data(raw)
 


### PR DESCRIPTION
**Description:**
Currently, none of the agent templates are having their reasoning logs properly captured and sent to the ARC-AGI environment. 

**The Bug:**
The official templates attach reasoning to the `GameAction` instance directly as an attribute (e.g. `action.reasoning = reasoning_meta`). However, `Agent.do_action_request()` attempts to extract the reasoning by looking *inside* `action.action_data.model_dump()`. Because `.reasoning` is an attribute on the `GameAction` instance and not part of the `action_data` Pydantic model, it always evaluates to `False` and an empty `{}` is passed to the environment `.step()` method instead.

**The Fix:**
Updated `do_action_request` to use `getattr(action, "reasoning", {})` natively.