### PR TITLE
Add OpenClaw agent template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,3 +28,9 @@ ARC_API_KEY=your_arc_api_key_here
 
 # AgentOps API Key
 AGENTOPS_API_KEY=your_agentops_api_key_here
+
+# OpenClaw Gateway (https://docs.openclaw.ai/gateway/openai-http-api)
+# Requires a running OpenClaw daemon with the OpenAI-compat HTTP endpoint enabled.
+OPENCLAW_BASE_URL=http://127.0.0.1:18789/v1
+OPENCLAW_GATEWAY_TOKEN=your_openclaw_gateway_token_here
+OPENCLAW_AGENT=openclaw/default

--- a/.env.example
+++ b/.env.example
@@ -37,8 +37,10 @@ OPENCLAW_GATEWAY_TOKEN=your_openclaw_gateway_token_here
 OPENCLAW_AGENT=openclaw/default
 # Optional: override the provider model per-request without editing
 # ~/.openclaw/openclaw.json. Sent as the documented `x-openclaw-model`
-# header. Examples: anthropic/claude-opus-4-7, openai/gpt-5, google/gemini-2.5-pro
-# OPENCLAW_MODEL=anthropic/claude-opus-4-7
+# header. Examples:
+#   OPENCLAW_MODEL=anthropic/claude-opus-4-7
+#   OPENCLAW_MODEL=openai/gpt-5
+#   OPENCLAW_MODEL=google/gemini-2.5-pro
 # Optional: pin a stable, resumable session key suffix. Defaults to a
 # random per-process value so each `uv run main.py` starts with a blank
 # OpenClaw conversation history.

--- a/.env.example
+++ b/.env.example
@@ -33,4 +33,13 @@ AGENTOPS_API_KEY=your_agentops_api_key_here
 # Requires a running OpenClaw daemon with the OpenAI-compat HTTP endpoint enabled.
 OPENCLAW_BASE_URL=http://127.0.0.1:18789/v1
 OPENCLAW_GATEWAY_TOKEN=your_openclaw_gateway_token_here
+# OpenClaw agent slug (routes the request to a configured agent).
 OPENCLAW_AGENT=openclaw/default
+# Optional: override the provider model per-request without editing
+# ~/.openclaw/openclaw.json. Sent as the documented `x-openclaw-model`
+# header. Examples: anthropic/claude-opus-4-7, openai/gpt-5, google/gemini-2.5-pro
+# OPENCLAW_MODEL=anthropic/claude-opus-4-7
+# Optional: pin a stable, resumable session key suffix. Defaults to a
+# random per-process value so each `uv run main.py` starts with a blank
+# OpenClaw conversation history.
+# OPENCLAW_RUN_ID=my-named-run

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -10,6 +10,7 @@ from .templates.langgraph_random_agent import LangGraphRandom
 from .templates.langgraph_thinking import LangGraphThinking
 from .templates.llm_agents import LLM, FastLLM, GuidedLLM, ReasoningLLM
 from .templates.multimodal import MultiModalLLM
+from .templates.openclaw_agent import OpenClaw
 from .templates.random_agent import Random
 from .templates.reasoning_agent import ReasoningAgent
 from .templates.smolagents import SmolCodingAgent, SmolVisionAgent
@@ -48,4 +49,5 @@ __all__ = [
     "Playback",
     "AVAILABLE_AGENTS",
     "MultiModalLLM",
+    "OpenClaw",
 ]

--- a/agents/agent.py
+++ b/agents/agent.py
@@ -132,11 +132,13 @@ class Agent(ABC):
 
     def do_action_request(self, action: GameAction) -> FrameData:
         data = action.action_data.model_dump()
-        raw = self.arc_env.step(
-            action,
-            data=data,
-            reasoning=data["reasoning"] if "reasoning" in data else {},
-        )
+        # Agents attach reasoning to the GameAction enum instance, not to
+        # action_data — read it from the enum so it actually reaches step().
+        # Some agents emit a bare string; wrap so the wrapper always sees a dict.
+        reasoning = getattr(action, "reasoning", None)
+        if reasoning is not None and not isinstance(reasoning, dict):
+            reasoning = {"text": str(reasoning)}
+        raw = self.arc_env.step(action, data=data, reasoning=reasoning)
         return self._convert_raw_frame_data(raw)
 
     def _convert_raw_frame_data(self, raw: FrameDataRaw | None) -> FrameData:

--- a/agents/templates/openclaw_agent/README.md
+++ b/agents/templates/openclaw_agent/README.md
@@ -91,6 +91,25 @@ uv sync
 uv run main.py --agent=openclaw --game=ls20
 ```
 
+### Selecting the underlying model
+
+By default the gateway uses whatever you set at
+`agents.defaults.model.primary` in `~/.openclaw/openclaw.json` during
+onboarding. To compare providers without editing that file, export
+`OPENCLAW_MODEL` before running — the agent forwards it as the documented
+`x-openclaw-model` header on each request:
+
+```bash
+OPENCLAW_MODEL=anthropic/claude-opus-4-7 uv run main.py --agent=openclaw --game=ls20
+OPENCLAW_MODEL=openai/gpt-5              uv run main.py --agent=openclaw --game=ls20
+```
+
+`OPENCLAW_AGENT` (default `openclaw/default`) selects the OpenClaw *agent
+slug* (which tools/prompts it uses); `OPENCLAW_MODEL` overrides the
+underlying *provider model* for that agent. The override is also folded
+into the agent's recorder subdirectory name so per-model traces don't
+collide.
+
 ## Notes
 
 - **Why not OpenAI-style `tools`?** OpenClaw's `/v1/chat/completions` endpoint
@@ -100,8 +119,13 @@ uv run main.py --agent=openclaw --game=ls20
   reply with one JSON object naming the action, and we parse it from
   `message.content`. Tolerant of stray markdown fences.
 - **Session memory.** Each game passes `x-openclaw-session-key:
-  arc:<card_id>:<game_id>`. OpenClaw uses this to retain conversation history
-  across the game's 80-action budget — the main edge over a stateless LLM call.
+  arc:<card_id>:<game_id>:<run-id>`. OpenClaw retains conversation history
+  across the game's 80-action budget under that key — the main edge over a
+  stateless LLM call. The `<run-id>` suffix is a random per-process value
+  (overridable with `OPENCLAW_RUN_ID=<name>`), so each fresh `uv run main.py`
+  starts with blank server-side memory while turns within one run still
+  share state. Old sessions accumulate server-side; periodically run
+  `openclaw sessions cleanup --enforce` to evict them.
 - **No new Python deps.** The existing `openai` SDK talks to OpenClaw's
   endpoint directly.
 - **Vision.** OpenClaw's compat API does not document image input, so the grid

--- a/agents/templates/openclaw_agent/README.md
+++ b/agents/templates/openclaw_agent/README.md
@@ -102,13 +102,18 @@ onboarding. To compare providers without editing that file, export
 ```bash
 OPENCLAW_MODEL=anthropic/claude-opus-4-7 uv run main.py --agent=openclaw --game=ls20
 OPENCLAW_MODEL=openai/gpt-5              uv run main.py --agent=openclaw --game=ls20
+OPENCLAW_MODEL=google/gemini-2.5-pro     uv run main.py --agent=openclaw --game=ls20
 ```
 
 `OPENCLAW_AGENT` (default `openclaw/default`) selects the OpenClaw *agent
 slug* (which tools/prompts it uses); `OPENCLAW_MODEL` overrides the
 underlying *provider model* for that agent. The override is also folded
 into the agent's recorder subdirectory name so per-model traces don't
-collide.
+collide. To enable a provider, drop its key into `docker/.env`
+(`ANTHROPIC_API_KEY`, `OPENAI_API_KEY`, `GEMINI_API_KEY`) and
+`docker compose up -d --force-recreate`. The compose startup strips the
+daemon's per-agent model allowlist so any provider with a key is
+callable — no manual config edits needed.
 
 ## Notes
 

--- a/agents/templates/openclaw_agent/README.md
+++ b/agents/templates/openclaw_agent/README.md
@@ -1,0 +1,110 @@
+# OpenClaw Agent
+
+Routes ARC-AGI-3 actions through a local [OpenClaw](https://openclaw.ai/) Gateway
+via its OpenAI-compatible HTTP API.
+
+The Python class is a thin shim: the actual agent loop runs in the OpenClaw
+daemon (Node, BYO LLM key). This satisfies "doesn't have to be Python only"
+while keeping the agent runnable from the existing `Swarm` and agent router.
+
+## How it fits
+
+```
+main.py --agent=openclaw --game=ls20
+        │
+        ▼
+   Swarm (agents/swarm.py)
+        │  one thread per game
+        ▼
+   OpenClaw (this file)
+        │  HTTPS /v1/chat/completions
+        ▼
+   OpenClaw Gateway (Node, localhost:18789)
+        │
+        ▼
+   Anthropic / OpenAI / Gemini / Ollama  (BYO key)
+```
+
+## Setup
+
+**Recommended: run the gateway via Docker Compose.** The compose file uses
+OpenClaw's published image, bind-mounts your host `~/.openclaw` config/workspace,
+publishes `127.0.0.1:18789`, and rewrites the workspace path inside the
+container so host-side OpenClaw onboarding works unchanged.
+
+```bash
+# 1. install the OpenClaw CLI and onboard with your provider key (one-time)
+npm install -g openclaw@latest
+openclaw onboard --non-interactive --accept-risk \
+  --auth-choice anthropic-api-key --anthropic-api-key sk-ant-...
+openclaw config set gateway.http.endpoints.chatCompletions.enabled true
+openclaw config set agents.defaults.model.primary anthropic/claude-haiku-4-5
+
+# 2. start the gateway in a container
+cd agents/templates/openclaw_agent/docker
+cp .env.example .env  # then edit and set ANTHROPIC_API_KEY
+docker compose up -d
+cd ../../../..
+
+# 3. wire the gateway token into the ARC .env (also has ARC_API_KEY)
+cp .env.example .env
+# edit .env and set OPENCLAW_GATEWAY_TOKEN to the value from:
+#   python3 -c "import json; print(json.load(open('$HOME/.openclaw/openclaw.json'))['gateway']['auth']['token'])"
+```
+
+If you'd rather skip Docker, the gateway also runs natively
+(`openclaw gateway run --port 18789`).
+
+### Docker Gateway
+
+Prerequisites: Docker Compose v2, an OpenClaw-supported provider key, and an
+OpenClaw config created by the setup commands above.
+
+```bash
+cd agents/templates/openclaw_agent/docker
+cp .env.example .env
+# edit .env and set ANTHROPIC_API_KEY or OPENAI_API_KEY
+docker compose up -d
+docker compose logs -f openclaw-gateway
+```
+
+Verify the gateway:
+
+```bash
+curl -sf http://127.0.0.1:18789/healthz
+TOKEN=$(python3 -c "import json; print(json.load(open('$HOME/.openclaw/openclaw.json'))['gateway']['auth']['token'])")
+curl -sf -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+  http://127.0.0.1:18789/v1/chat/completions \
+  -d '{"model":"openclaw/default","messages":[{"role":"user","content":"reply OK"}]}'
+```
+
+Stop it with:
+
+```bash
+docker compose down
+```
+
+## Run
+
+```bash
+uv sync
+uv run main.py --agent=openclaw --game=ls20
+```
+
+## Notes
+
+- **Why not OpenAI-style `tools`?** OpenClaw's `/v1/chat/completions` endpoint
+  silently drops the `tools` field for some backends (verified 2026-05 against
+  the Anthropic provider — the upstream model never sees the schema). This
+  agent uses a **JSON-in-text protocol** instead: the prompt asks the model to
+  reply with one JSON object naming the action, and we parse it from
+  `message.content`. Tolerant of stray markdown fences.
+- **Session memory.** Each game passes `x-openclaw-session-key:
+  arc:<card_id>:<game_id>`. OpenClaw uses this to retain conversation history
+  across the game's 80-action budget — the main edge over a stateless LLM call.
+- **No new Python deps.** The existing `openai` SDK talks to OpenClaw's
+  endpoint directly.
+- **Vision.** OpenClaw's compat API does not document image input, so the grid
+  is serialized as hex text. If you want a multimodal variant later, you'd add
+  `image_url` content blocks and verify the configured underlying model
+  accepts them.

--- a/agents/templates/openclaw_agent/README.md
+++ b/agents/templates/openclaw_agent/README.md
@@ -123,9 +123,11 @@ toolkit reasoning-logs docs][reasoning-docs] alongside the action:
 }
 ```
 
-`thought` is clipped to 1000 chars, `alternatives_considered` to 5 items × 200
-chars each, and `confidence` is clamped to `[0,1]`. These limits keep the
-payload well under `arcengine`'s 16 KB cap (`MAX_REASONING_BYTES`).
+`alternatives_considered` is clipped to 5 items × 200 chars each, and
+`confidence` is clamped to `[0,1]`. `thought` passes through verbatim; the
+agent only trims it if the full JSON payload would exceed `arcengine`'s 16 KB
+cap (`MAX_REASONING_BYTES`), preserving as much justification as possible for
+trace analysis.
 
 `reasoning_tokens` reads `response.usage.completion_tokens_details.reasoning_tokens`.
 OpenClaw's compat layer doesn't surface that telemetry today (verified against

--- a/agents/templates/openclaw_agent/README.md
+++ b/agents/templates/openclaw_agent/README.md
@@ -108,3 +108,29 @@ uv run main.py --agent=openclaw --game=ls20
   is serialized as hex text. If you want a multimodal variant later, you'd add
   `image_url` content blocks and verify the configured underlying model
   accepts them.
+
+## Reasoning fields
+
+Each turn's JSON reply must include the four fields described in the [ARC
+toolkit reasoning-logs docs][reasoning-docs] alongside the action:
+
+```json
+{
+  "action": "ACTION1",
+  "thought": "Player is below the door; moving up should advance.",
+  "confidence": 0.8,
+  "alternatives_considered": ["ACTION4 to test right wall"]
+}
+```
+
+`thought` is clipped to 1000 chars, `alternatives_considered` to 5 items × 200
+chars each, and `confidence` is clamped to `[0,1]`. These limits keep the
+payload well under `arcengine`'s 16 KB cap (`MAX_REASONING_BYTES`).
+
+`reasoning_tokens` reads `response.usage.completion_tokens_details.reasoning_tokens`.
+OpenClaw's compat layer doesn't surface that telemetry today (verified against
+v2026.5.7's `normalizeUsage`, which has no reasoning/thinking slot), so the
+field reports `0` for OpenClaw replies. It will populate automatically once
+the gateway forwards the upstream provider's reasoning-token count.
+
+[reasoning-docs]: https://docs.arcprize.org/toolkit/submit-action#including-reasoning-logs

--- a/agents/templates/openclaw_agent/__init__.py
+++ b/agents/templates/openclaw_agent/__init__.py
@@ -1,0 +1,3 @@
+from .openclaw_agent import OpenClaw
+
+__all__ = ["OpenClaw"]

--- a/agents/templates/openclaw_agent/docker/.env.example
+++ b/agents/templates/openclaw_agent/docker/.env.example
@@ -1,0 +1,15 @@
+# Provider keys passed into the OpenClaw container. At least one provider key
+# must be set for OpenClaw to actually call an upstream LLM.
+ANTHROPIC_API_KEY=
+OPENAI_API_KEY=
+
+# Reuses the token already persisted in ~/.openclaw/openclaw.json. Leave empty
+# to use whatever the mounted config file specifies.
+OPENCLAW_GATEWAY_TOKEN=
+
+# Override the host-side path that gets bind-mounted into the container.
+# Defaults to ~/.openclaw on the host.
+# OPENCLAW_HOST_CONFIG_DIR=/Users/you/.openclaw
+
+# Pin a specific OpenClaw image tag instead of `latest`.
+# OPENCLAW_IMAGE=ghcr.io/openclaw/openclaw:2026.5.7

--- a/agents/templates/openclaw_agent/docker/.env.example
+++ b/agents/templates/openclaw_agent/docker/.env.example
@@ -1,7 +1,19 @@
-# Provider keys passed into the OpenClaw container. At least one provider key
-# must be set for OpenClaw to actually call an upstream LLM.
+# Provider API keys. Anything you put here is passed through to the OpenClaw
+# container — adding a provider is just "drop the key here", no compose edits.
+# With the compose-side allowlist strip (see docker-compose.yml note #2), any
+# provider with a key here is selectable via OPENCLAW_MODEL=<provider>/<model>.
+# Common ones below; see https://docs.openclaw.ai/providers for the full list.
 ANTHROPIC_API_KEY=
 OPENAI_API_KEY=
+# Google reads GEMINI_API_KEY first; GOOGLE_API_KEY is the documented fallback.
+GEMINI_API_KEY=
+# Additional providers OpenClaw supports — uncomment and fill as needed:
+# XAI_API_KEY=
+# GROQ_API_KEY=
+# DEEPSEEK_API_KEY=
+# MISTRAL_API_KEY=
+# OPENROUTER_API_KEY=
+# TOGETHER_API_KEY=
 
 # Reuses the token already persisted in ~/.openclaw/openclaw.json. Leave empty
 # to use whatever the mounted config file specifies.

--- a/agents/templates/openclaw_agent/docker/docker-compose.yml
+++ b/agents/templates/openclaw_agent/docker/docker-compose.yml
@@ -8,6 +8,11 @@
 services:
   openclaw-gateway:
     image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}
+    # Provider API keys (ANTHROPIC_API_KEY, OPENAI_API_KEY, GEMINI_API_KEY, etc.)
+    # are loaded from .env via env_file and passed straight through to the
+    # container. Adding a new provider is just "drop the key in .env" — no
+    # compose edits needed. See https://docs.openclaw.ai/providers for which
+    # env var each provider reads.
     env_file:
       - path: .env
         required: false
@@ -15,9 +20,6 @@ services:
       HOME: /home/node
       OPENCLAW_CONFIG_DIR: /home/node/.openclaw
       OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
-      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
-      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
-      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       # Bonjour discovery is pointless inside a container and noisy in logs.
       OPENCLAW_DISABLE_BONJOUR: "1"
       TZ: ${OPENCLAW_TZ:-UTC}
@@ -37,7 +39,7 @@ services:
     init: true
     restart: unless-stopped
     command:
-      # Two things going on here:
+      # Four things going on here:
       # 1. The bind-mounted openclaw.json has `agents.defaults.workspace` set
       #    to a host absolute path (e.g. /Users/<you>/.openclaw/workspace).
       #    That path doesn't exist in the container and OpenClaw tries to
@@ -45,7 +47,23 @@ services:
       #    config out, rewrite the path to the container-side mount point,
       #    and point OPENCLAW_CONFIG_PATH at the copy. The host config is
       #    left untouched.
-      # 2. Inside the container we MUST bind to all interfaces. Docker
+      # 2. `agents.defaults.models` is OpenClaw's strict allowlist for the
+      #    `x-openclaw-model` header — provider/* wildcards apply to the
+      #    `/model` picker only, NOT to API header validation (verified
+      #    against http-utils-3xCgv22F.js:47 + model-selection-shared-
+      #    DOxyWoaQ.js:480 in v2026.5.7: `allowAny = rawAllowlist.length
+      #    === 0`). Onboarding typically seeds it with sonnet+haiku, which
+      #    makes OPENCLAW_MODEL=openai/gpt-5 fail with 400. We strip it
+      #    so any provider/model the daemon has a credential for is
+      #    callable via the env var. Provider plugins themselves auto-load
+      #    from API keys in the container env — `plugins.entries` doesn't
+      #    need to list each provider for routing.
+      # 3. The OpenAI-compat `/v1/chat/completions` endpoint is opt-in
+      #    (`gateway.http.endpoints.chatCompletions.enabled`). Onboarding
+      #    doesn't enable it, and the ARC agent talks to this endpoint, so
+      #    we force-enable it here. Without this the gateway returns 404
+      #    for every request.
+      # 4. Inside the container we MUST bind to all interfaces. Docker
       #    forwards host port traffic to the container's eth0, not its
       #    loopback; the "127.0.0.1:" prefix on the port mapping below is
       #    what keeps the gateway loopback-only from outside.
@@ -59,6 +77,11 @@ services:
           c.agents = c.agents || {};
           c.agents.defaults = c.agents.defaults || {};
           c.agents.defaults.workspace = '/home/node/.openclaw/workspace';
+          delete c.agents.defaults.models;
+          c.gateway = c.gateway || {};
+          c.gateway.http = c.gateway.http || {};
+          c.gateway.http.endpoints = c.gateway.http.endpoints || {};
+          c.gateway.http.endpoints.chatCompletions = { ...(c.gateway.http.endpoints.chatCompletions || {}), enabled: true };
           fs.writeFileSync('/tmp/openclaw.json', JSON.stringify(c, null, 2));
         "
         export OPENCLAW_CONFIG_PATH=/tmp/openclaw.json

--- a/agents/templates/openclaw_agent/docker/docker-compose.yml
+++ b/agents/templates/openclaw_agent/docker/docker-compose.yml
@@ -1,0 +1,75 @@
+# Runs the OpenClaw gateway in a container, bind-mounting your existing
+# ~/.openclaw config and workspace so the ARC agent's tokens, default model,
+# and skills carry over unchanged.
+#
+# Loopback-only — port 18789 is published on 127.0.0.1 only.
+# The ARC agent on the host hits http://127.0.0.1:18789/v1/chat/completions.
+
+services:
+  openclaw-gateway:
+    image: ${OPENCLAW_IMAGE:-ghcr.io/openclaw/openclaw:latest}
+    env_file:
+      - path: .env
+        required: false
+    environment:
+      HOME: /home/node
+      OPENCLAW_CONFIG_DIR: /home/node/.openclaw
+      OPENCLAW_WORKSPACE_DIR: /home/node/.openclaw/workspace
+      OPENCLAW_GATEWAY_TOKEN: ${OPENCLAW_GATEWAY_TOKEN:-}
+      ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
+      OPENAI_API_KEY: ${OPENAI_API_KEY:-}
+      # Bonjour discovery is pointless inside a container and noisy in logs.
+      OPENCLAW_DISABLE_BONJOUR: "1"
+      TZ: ${OPENCLAW_TZ:-UTC}
+    volumes:
+      - ${OPENCLAW_HOST_CONFIG_DIR:-${HOME}/.openclaw}:/home/node/.openclaw
+    cap_drop:
+      - NET_RAW
+      - NET_ADMIN
+    security_opt:
+      - no-new-privileges:true
+    extra_hosts:
+      # Let bundled local-model providers (Ollama/LM Studio) reach the host.
+      - "host.docker.internal:host-gateway"
+    ports:
+      # 127.0.0.1: prefix forces loopback-only publication.
+      - "127.0.0.1:${OPENCLAW_GATEWAY_PORT:-18789}:18789"
+    init: true
+    restart: unless-stopped
+    command:
+      # Two things going on here:
+      # 1. The bind-mounted openclaw.json has `agents.defaults.workspace` set
+      #    to a host absolute path (e.g. /Users/<you>/.openclaw/workspace).
+      #    That path doesn't exist in the container and OpenClaw tries to
+      #    mkdir it on first chat-completion, hitting EACCES. We copy the
+      #    config out, rewrite the path to the container-side mount point,
+      #    and point OPENCLAW_CONFIG_PATH at the copy. The host config is
+      #    left untouched.
+      # 2. Inside the container we MUST bind to all interfaces. Docker
+      #    forwards host port traffic to the container's eth0, not its
+      #    loopback; the "127.0.0.1:" prefix on the port mapping below is
+      #    what keeps the gateway loopback-only from outside.
+      - sh
+      - -ec
+      - |
+        cp /home/node/.openclaw/openclaw.json /tmp/openclaw.json
+        node -e "
+          const fs = require('fs');
+          const c = JSON.parse(fs.readFileSync('/tmp/openclaw.json', 'utf8'));
+          c.agents = c.agents || {};
+          c.agents.defaults = c.agents.defaults || {};
+          c.agents.defaults.workspace = '/home/node/.openclaw/workspace';
+          fs.writeFileSync('/tmp/openclaw.json', JSON.stringify(c, null, 2));
+        "
+        export OPENCLAW_CONFIG_PATH=/tmp/openclaw.json
+        exec node dist/index.js gateway --bind lan --port 18789
+    healthcheck:
+      test:
+        - CMD
+        - node
+        - -e
+        - "fetch('http://127.0.0.1:18789/healthz').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s

--- a/agents/templates/openclaw_agent/openclaw_agent.py
+++ b/agents/templates/openclaw_agent/openclaw_agent.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import textwrap
+import uuid
 from typing import Any, Optional
 
 import openai
@@ -21,6 +22,13 @@ from openai import OpenAI as OpenAIClient
 from ...agent import Agent
 
 logger = logging.getLogger()
+
+# One run-id per Python process: every fresh `uv run main.py` gets a new
+# value, so OpenClaw's server-side session memory starts blank each run.
+# Multiple games inside one Swarm run share the same suffix, which is fine —
+# their card_id/game_id still keep the per-game sessions distinct. Override
+# with OPENCLAW_RUN_ID=<name> to pin a stable, resumable session.
+_RUN_ID = os.environ.get("OPENCLAW_RUN_ID") or uuid.uuid4().hex[:8]
 
 
 class OpenClaw(Agent):
@@ -34,8 +42,13 @@ class OpenClaw(Agent):
     token_counter: int
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        # Parent __init__ uses self.name, which reads self.model — set it first.
+        # Parent __init__ uses self.name, which reads self.model and the
+        # model override — set both before super().__init__.
         self.model = os.environ.get("OPENCLAW_AGENT", self.DEFAULT_AGENT)
+        # OPENCLAW_MODEL overrides the gateway's configured default model
+        # per-request (sent as x-openclaw-model on each call) so callers
+        # can compare providers without editing ~/.openclaw/openclaw.json.
+        self._model_override = os.environ.get("OPENCLAW_MODEL") or None
         super().__init__(*args, **kwargs)
         self.token_counter = 0
         base_url = os.environ.get("OPENCLAW_BASE_URL", self.DEFAULT_BASE_URL)
@@ -44,7 +57,9 @@ class OpenClaw(Agent):
         # below pins all turns of one game to a persistent agent session
         # so OpenClaw retains conversation history server-side — that's
         # why choose_action only sends the new user message each turn.
-        self._session_key = f"arc:{self.card_id}:{self.game_id}"
+        # The _RUN_ID suffix rotates the key every process so a new
+        # `uv run main.py` starts with blank server-side memory.
+        self._session_key = f"arc:{self.card_id}:{self.game_id}:{_RUN_ID}"
         self._client = OpenAIClient(
             base_url=base_url,
             api_key=token or "no-auth",  # required by SDK; ignored when auth.mode=none
@@ -52,12 +67,16 @@ class OpenClaw(Agent):
         )
         logger.info(
             f"OpenClaw agent for {self.game_id} -> {base_url} model={self.model} "
+            f"model_override={self._model_override or '(none)'} "
             f"session={self._session_key}"
         )
 
     @property
     def name(self) -> str:
-        sanitized = self.model.replace("/", "-").replace(":", "-")
+        parts = [self.model]
+        if self._model_override:
+            parts.append(self._model_override)
+        sanitized = ".".join(p.replace("/", "-").replace(":", "-") for p in parts)
         return f"{super().name}.{sanitized}"
 
     def is_done(self, frames: list[FrameData], latest_frame: FrameData) -> bool:
@@ -81,10 +100,18 @@ class OpenClaw(Agent):
         # field for some providers (verified May 2026 against Anthropic),
         # so the agent uses a JSON-in-text protocol instead.
         prompt = self._build_prompt(latest_frame)
+        # `model` here is the OpenClaw agent slug; the underlying provider
+        # model is whatever that agent's primary is in ~/.openclaw/openclaw.json.
+        # OPENCLAW_MODEL, if set, overrides the provider model per request via
+        # the documented x-openclaw-model header.
+        extra_headers = (
+            {"x-openclaw-model": self._model_override} if self._model_override else None
+        )
         try:
             response = self._client.chat.completions.create(
                 model=self.model,
                 messages=[{"role": "user", "content": prompt}],
+                extra_headers=extra_headers,
             )
         except openai.BadRequestError as e:
             logger.error(f"OpenClaw 400: {e}")
@@ -98,12 +125,12 @@ class OpenClaw(Agent):
 
         blob = self._parse_blob(msg)
         action = self._action_from_blob(blob)
-        action.reasoning = self._extract_reasoning(blob)
+        # GameAction.reasoning is set dynamically by the toolkit (same pattern
+        # as agents/agent.py:259, random_agent.py, multimodal.py).
+        action.reasoning = self._extract_reasoning(blob)  # type: ignore[attr-defined]
         return action
 
-    def _parse_action(
-        self, msg: Any, latest_frame: FrameData
-    ) -> GameAction:
+    def _parse_action(self, msg: Any, latest_frame: FrameData) -> GameAction:
         return self._action_from_blob(self._parse_blob(msg))
 
     _JSON_BLOB = re.compile(r"\{[^{}]*\"action\"[^{}]*\}", re.DOTALL)
@@ -173,7 +200,9 @@ class OpenClaw(Agent):
         # reasoning_tokens stays 0: OpenClaw v2026.5.7's normalizeUsage has
         # no reasoning slot. Read the real field here if OpenClaw forwards it.
         parsed = isinstance(blob, dict)
-        src = blob if parsed else {}
+        # Re-stating the isinstance on this line (instead of using `parsed`)
+        # lets mypy narrow `src` to dict[str, Any] for the .get() calls below.
+        src: dict[str, Any] = blob if isinstance(blob, dict) else {}
 
         thought_raw = src.get("thought")
         thought = str(thought_raw).strip() if thought_raw else ""
@@ -188,16 +217,20 @@ class OpenClaw(Agent):
 
         raw_alts = src.get("alternatives_considered")
         if isinstance(raw_alts, list):
-            alternatives = [str(a)[: cls._MAX_ALT_CHARS] for a in raw_alts[: cls._MAX_ALTS]]
+            alternatives = [
+                str(a)[: cls._MAX_ALT_CHARS] for a in raw_alts[: cls._MAX_ALTS]
+            ]
         else:
             alternatives = []
 
-        return cls._enforce_size({
-            "thought": thought,
-            "confidence": confidence,
-            "alternatives_considered": alternatives,
-            "reasoning_tokens": 0,
-        })
+        return cls._enforce_size(
+            {
+                "thought": thought,
+                "confidence": confidence,
+                "alternatives_considered": alternatives,
+                "reasoning_tokens": 0,
+            }
+        )
 
     @classmethod
     def _enforce_size(cls, payload: dict[str, Any]) -> dict[str, Any]:
@@ -235,8 +268,9 @@ class OpenClaw(Agent):
         )
 
     def _build_prompt(self, latest_frame: FrameData) -> str:
-        return textwrap.dedent(
-            """
+        return (
+            textwrap.dedent(
+                """
             You are playing an unfamiliar turn-based grid game. Reach state=WIN
             to win. Each turn provides the latest observed frame and the legal
             actions for that state.
@@ -292,13 +326,16 @@ class OpenClaw(Agent):
             # GRID (hex)
             {grid}
             """
-        ).strip().format(
-            game_id=latest_frame.game_id,
-            state=latest_frame.state.name,
-            levels=latest_frame.levels_completed,
-            win_levels=latest_frame.win_levels,
-            available=self._action_names(latest_frame.available_actions),
-            grid=self._render_grid(latest_frame.frame),
+            )
+            .strip()
+            .format(
+                game_id=latest_frame.game_id,
+                state=latest_frame.state.name,
+                levels=latest_frame.levels_completed,
+                win_levels=latest_frame.win_levels,
+                available=self._action_names(latest_frame.available_actions),
+                grid=self._render_grid(latest_frame.frame),
+            )
         )
 
     def _action_names(self, actions: Optional[list[Any]]) -> list[str]:
@@ -332,6 +369,8 @@ class OpenClaw(Agent):
             self.recorder.record(
                 {
                     "openclaw_model": self.model,
+                    "openclaw_model_override": self._model_override,
+                    "openclaw_session_key": self._session_key,
                     "openclaw_total_tokens": self.token_counter,
                 }
             )

--- a/agents/templates/openclaw_agent/openclaw_agent.py
+++ b/agents/templates/openclaw_agent/openclaw_agent.py
@@ -162,9 +162,9 @@ class OpenClaw(Agent):
                 action.set_data({"x": 32, "y": 32})
         return action
 
-    # Truncation limits keep the payload under arcengine's 16 KB cap
-    # (MAX_REASONING_BYTES, enums.py:14).
-    _MAX_THOUGHT_CHARS = 1000
+    # Mirror of arcengine.enums.MAX_REASONING_BYTES. Structured-field caps
+    # below are defensive; the final size enforcement is what guarantees fit.
+    _MAX_REASONING_BYTES = 16 * 1024
     _MAX_ALT_CHARS = 200
     _MAX_ALTS = 5
 
@@ -176,7 +176,7 @@ class OpenClaw(Agent):
         src = blob if parsed else {}
 
         thought_raw = src.get("thought")
-        thought = str(thought_raw).strip()[: cls._MAX_THOUGHT_CHARS] if thought_raw else ""
+        thought = str(thought_raw).strip() if thought_raw else ""
         if not thought:
             thought = "(no thought provided)" if parsed else "(parse failed)"
 
@@ -192,12 +192,32 @@ class OpenClaw(Agent):
         else:
             alternatives = []
 
-        return {
+        return cls._enforce_size({
             "thought": thought,
             "confidence": confidence,
             "alternatives_considered": alternatives,
             "reasoning_tokens": 0,
-        }
+        })
+
+    @classmethod
+    def _enforce_size(cls, payload: dict[str, Any]) -> dict[str, Any]:
+        # Trim `thought` (the largest, least-structured field) until the JSON
+        # payload fits under arcengine's MAX_REASONING_BYTES cap. The doc
+        # emphasizes keeping the justification, so trimming it is preferable
+        # to letting the server reject the whole step.
+        while True:
+            raw = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+            excess = len(raw) - cls._MAX_REASONING_BYTES
+            if excess <= 0:
+                return payload
+            thought = payload.get("thought", "")
+            if not thought:
+                return payload  # nothing left to trim
+            # Drop excess chars plus a small margin to absorb JSON-escape growth.
+            new_len = max(0, len(thought) - excess - 16)
+            if new_len >= len(thought):
+                return payload  # no progress possible
+            payload["thought"] = thought[:new_len]
 
     def _track_tokens(self, tokens: int, content: str) -> None:
         self.token_counter += tokens

--- a/agents/templates/openclaw_agent/openclaw_agent.py
+++ b/agents/templates/openclaw_agent/openclaw_agent.py
@@ -96,33 +96,41 @@ class OpenClaw(Agent):
         if response.usage:
             self._track_tokens(response.usage.total_tokens, msg.content or "")
 
-        return self._parse_action(msg, latest_frame)
-
-    _JSON_BLOB = re.compile(r"\{[^{}]*\"action\"[^{}]*\}", re.DOTALL)
+        blob = self._parse_blob(msg)
+        action = self._action_from_blob(blob)
+        action.reasoning = self._extract_reasoning(blob)
+        return action
 
     def _parse_action(
         self, msg: Any, latest_frame: FrameData
     ) -> GameAction:
-        # The inline prompt asks for one JSON object naming the action. Tolerate
-        # stray whitespace, markdown fences, or leading prose by extracting the
-        # first {...} block containing "action".
-        text = (msg.content or "").strip()
-        blob = None
-        if text:
-            try:
-                blob = json.loads(text)
-            except json.JSONDecodeError:
-                match = self._JSON_BLOB.search(text)
-                if match:
-                    try:
-                        blob = json.loads(match.group(0))
-                    except json.JSONDecodeError:
-                        blob = None
+        return self._action_from_blob(self._parse_blob(msg))
 
+    _JSON_BLOB = re.compile(r"\{[^{}]*\"action\"[^{}]*\}", re.DOTALL)
+
+    def _parse_blob(self, msg: Any) -> Optional[dict[str, Any]]:
+        text = (msg.content or "").strip()
+        if not text:
+            return None
+        try:
+            parsed = json.loads(text)
+            if isinstance(parsed, dict):
+                return parsed
+        except json.JSONDecodeError:
+            pass
+        match = self._JSON_BLOB.search(text)
+        if match is None:
+            return None
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return None
+        return parsed if isinstance(parsed, dict) else None
+
+    def _action_from_blob(self, blob: Optional[dict[str, Any]]) -> GameAction:
         if not isinstance(blob, dict) or "action" not in blob:
             logger.warning(
-                f"OpenClaw reply did not parse to action JSON; "
-                f"falling back to ACTION5. raw={text[:200]!r}"
+                "OpenClaw reply did not parse to action JSON; falling back to ACTION5."
             )
             return GameAction.ACTION5
 
@@ -153,6 +161,43 @@ class OpenClaw(Agent):
             except (TypeError, ValueError):
                 action.set_data({"x": 32, "y": 32})
         return action
+
+    # Truncation limits keep the payload under arcengine's 16 KB cap
+    # (MAX_REASONING_BYTES, enums.py:14).
+    _MAX_THOUGHT_CHARS = 1000
+    _MAX_ALT_CHARS = 200
+    _MAX_ALTS = 5
+
+    @classmethod
+    def _extract_reasoning(cls, blob: Optional[dict[str, Any]]) -> dict[str, Any]:
+        # reasoning_tokens stays 0: OpenClaw v2026.5.7's normalizeUsage has
+        # no reasoning slot. Read the real field here if OpenClaw forwards it.
+        parsed = isinstance(blob, dict)
+        src = blob if parsed else {}
+
+        thought_raw = src.get("thought")
+        thought = str(thought_raw).strip()[: cls._MAX_THOUGHT_CHARS] if thought_raw else ""
+        if not thought:
+            thought = "(no thought provided)" if parsed else "(parse failed)"
+
+        try:
+            confidence = float(src.get("confidence", 0.0))
+        except (TypeError, ValueError):
+            confidence = 0.0
+        confidence = max(0.0, min(1.0, confidence))
+
+        raw_alts = src.get("alternatives_considered")
+        if isinstance(raw_alts, list):
+            alternatives = [str(a)[: cls._MAX_ALT_CHARS] for a in raw_alts[: cls._MAX_ALTS]]
+        else:
+            alternatives = []
+
+        return {
+            "thought": thought,
+            "confidence": confidence,
+            "alternatives_considered": alternatives,
+            "reasoning_tokens": 0,
+        }
 
     def _track_tokens(self, tokens: int, content: str) -> None:
         self.token_counter += tokens
@@ -186,13 +231,22 @@ class OpenClaw(Agent):
             control.
 
             After any tool use, your FINAL response must be one JSON object
-            naming the action to take. No prose around it, no markdown fence.
+            containing the action AND a brief reasoning trace. No prose
+            around it, no markdown fence.
+
+            Required keys:
+              "action": one of "RESET", "ACTION1".."ACTION5", "ACTION7",
+                       or "ACTION6" with extra integer "x","y" in [0,63].
+              "thought": one short sentence (<=200 chars) on why this action.
+              "confidence": number in [0,1] (use 0.5 if unsure).
+              "alternatives_considered": array of up to 4 short strings
+                                         describing other actions weighed
+                                         (use [] if none).
 
             Examples (use these literal string values for "action"):
-              {{"action":"ACTION1"}}
-              {{"action":"ACTION3"}}
-              {{"action":"ACTION6","x":12,"y":34}}
-              {{"action":"RESET"}}
+              {{"action":"ACTION1","thought":"Player is below the door; moving up should advance.","confidence":0.8,"alternatives_considered":["ACTION4 to test right wall"]}}
+              {{"action":"ACTION6","x":12,"y":34,"thought":"Click the lone red square.","confidence":0.6,"alternatives_considered":[]}}
+              {{"action":"RESET","thought":"State is GAME_OVER; restart.","confidence":1.0,"alternatives_considered":[]}}
 
             Action meanings:
               "RESET"=start/restart.

--- a/agents/templates/openclaw_agent/openclaw_agent.py
+++ b/agents/templates/openclaw_agent/openclaw_agent.py
@@ -125,9 +125,7 @@ class OpenClaw(Agent):
 
         blob = self._parse_blob(msg)
         action = self._action_from_blob(blob)
-        # GameAction.reasoning is set dynamically by the toolkit (same pattern
-        # as agents/agent.py:259, random_agent.py, multimodal.py).
-        action.reasoning = self._extract_reasoning(blob)  # type: ignore[attr-defined]
+        action.reasoning = self._extract_reasoning(blob)
         return action
 
     def _parse_action(self, msg: Any, latest_frame: FrameData) -> GameAction:

--- a/agents/templates/openclaw_agent/openclaw_agent.py
+++ b/agents/templates/openclaw_agent/openclaw_agent.py
@@ -1,0 +1,264 @@
+"""OpenClaw agent.
+
+Thin Python shim that routes ARC-AGI-3 actions through the OpenClaw Gateway's
+OpenAI-compatible HTTP API (https://docs.openclaw.ai/gateway/openai-http-api).
+The actual agent runs in the OpenClaw daemon (Node, BYO LLM key); this class
+only translates between the ARC Agent contract and OpenClaw's chat-completions
+endpoint, so it plugs into the existing Swarm + agent router unchanged.
+"""
+
+import json
+import logging
+import os
+import re
+import textwrap
+from typing import Any, Optional
+
+import openai
+from arcengine import FrameData, GameAction, GameState
+from openai import OpenAI as OpenAIClient
+
+from ...agent import Agent
+
+logger = logging.getLogger()
+
+
+class OpenClaw(Agent):
+    """An agent that uses an OpenClaw Gateway to play games."""
+
+    MAX_ACTIONS: int = 80
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:18789/v1"
+    DEFAULT_AGENT = "openclaw/default"
+
+    token_counter: int
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        # Parent __init__ uses self.name, which reads self.model — set it first.
+        self.model = os.environ.get("OPENCLAW_AGENT", self.DEFAULT_AGENT)
+        super().__init__(*args, **kwargs)
+        self.token_counter = 0
+        base_url = os.environ.get("OPENCLAW_BASE_URL", self.DEFAULT_BASE_URL)
+        token = os.environ.get("OPENCLAW_GATEWAY_TOKEN", "")
+        # OpenClaw is stateless per request by default. The session key
+        # below pins all turns of one game to a persistent agent session
+        # so OpenClaw retains conversation history server-side — that's
+        # why choose_action only sends the new user message each turn.
+        self._session_key = f"arc:{self.card_id}:{self.game_id}"
+        self._client = OpenAIClient(
+            base_url=base_url,
+            api_key=token or "no-auth",  # required by SDK; ignored when auth.mode=none
+            default_headers={"x-openclaw-session-key": self._session_key},
+        )
+        logger.info(
+            f"OpenClaw agent for {self.game_id} -> {base_url} model={self.model} "
+            f"session={self._session_key}"
+        )
+
+    @property
+    def name(self) -> str:
+        sanitized = self.model.replace("/", "-").replace(":", "-")
+        return f"{super().name}.{sanitized}"
+
+    def is_done(self, frames: list[FrameData], latest_frame: FrameData) -> bool:
+        return latest_frame.state is GameState.WIN
+
+    def choose_action(
+        self, frames: list[FrameData], latest_frame: FrameData
+    ) -> GameAction:
+        # NOT_PLAYED on first call, GAME_OVER after a fail. Either way the only
+        # legal action is RESET; spend zero tokens on it.
+        if latest_frame.state in (GameState.NOT_PLAYED, GameState.GAME_OVER):
+            return GameAction.RESET
+
+        # OpenClaw is a stateful gateway: the x-openclaw-session-key header
+        # we set in __init__ scopes a persistent agent session, so we only
+        # send the NEW user message each turn. The OpenClaw daemon stitches
+        # this onto its server-side conversation history before forwarding
+        # to the upstream provider. Sending our own accumulated history
+        # here would duplicate the conversation and defeat prompt caching.
+        # OpenClaw's OpenAI-compat layer also silently drops the `tools`
+        # field for some providers (verified May 2026 against Anthropic),
+        # so the agent uses a JSON-in-text protocol instead.
+        prompt = self._build_prompt(latest_frame)
+        try:
+            response = self._client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": prompt}],
+            )
+        except openai.BadRequestError as e:
+            logger.error(f"OpenClaw 400: {e}")
+            logger.error(f"prompt: {prompt[:500]}")
+            raise
+
+        msg = response.choices[0].message
+
+        if response.usage:
+            self._track_tokens(response.usage.total_tokens, msg.content or "")
+
+        return self._parse_action(msg, latest_frame)
+
+    _JSON_BLOB = re.compile(r"\{[^{}]*\"action\"[^{}]*\}", re.DOTALL)
+
+    def _parse_action(
+        self, msg: Any, latest_frame: FrameData
+    ) -> GameAction:
+        # The inline prompt asks for one JSON object naming the action. Tolerate
+        # stray whitespace, markdown fences, or leading prose by extracting the
+        # first {...} block containing "action".
+        text = (msg.content or "").strip()
+        blob = None
+        if text:
+            try:
+                blob = json.loads(text)
+            except json.JSONDecodeError:
+                match = self._JSON_BLOB.search(text)
+                if match:
+                    try:
+                        blob = json.loads(match.group(0))
+                    except json.JSONDecodeError:
+                        blob = None
+
+        if not isinstance(blob, dict) or "action" not in blob:
+            logger.warning(
+                f"OpenClaw reply did not parse to action JSON; "
+                f"falling back to ACTION5. raw={text[:200]!r}"
+            )
+            return GameAction.ACTION5
+
+        raw = str(blob.get("action", "")).upper().strip()
+        # Accept either the canonical name ("ACTION1", "RESET") or the integer
+        # id ("1", "0"). GameAction is a plain Enum (not IntEnum) so we look
+        # up by .value rather than constructor.
+        action: Optional[GameAction] = None
+        try:
+            action = GameAction.from_name(raw)
+        except (KeyError, ValueError, AttributeError):
+            try:
+                wanted = int(raw)
+                action = next((a for a in GameAction if a.value == wanted), None)
+            except (TypeError, ValueError):
+                action = None
+        if action is None:
+            logger.warning(
+                f"OpenClaw returned unknown action {raw!r}; falling back to ACTION5"
+            )
+            return GameAction.ACTION5
+
+        if action.is_complex():
+            try:
+                action.set_data(
+                    {"x": int(blob.get("x", 32)), "y": int(blob.get("y", 32))}
+                )
+            except (TypeError, ValueError):
+                action.set_data({"x": 32, "y": 32})
+        return action
+
+    def _track_tokens(self, tokens: int, content: str) -> None:
+        self.token_counter += tokens
+        if hasattr(self, "recorder") and not self.is_playback:
+            self.recorder.record(
+                {
+                    "tokens": tokens,
+                    "total_tokens": self.token_counter,
+                    "assistant": content,
+                }
+            )
+        logger.info(
+            f"OpenClaw used {tokens} tokens (total {self.token_counter}) "
+            f"for {self.game_id}"
+        )
+
+    def _build_prompt(self, latest_frame: FrameData) -> str:
+        return textwrap.dedent(
+            """
+            You are playing an unfamiliar turn-based grid game. Reach state=WIN
+            to win. Each turn provides the latest observed frame and the legal
+            actions for that state.
+
+            You may use OpenClaw's built-in memory and file tools to keep
+            persistent notes between turns about anything you've figured out:
+            object identities, control effects, goals, hazards, counters,
+            positions, repeated failures, hypotheses to test, and action
+            sequences that helped. Read your notes at the start of a turn;
+            update them when you observe something new. The session retains the
+            conversation history but notes give you a stable scratchpad you
+            control.
+
+            After any tool use, your FINAL response must be one JSON object
+            naming the action to take. No prose around it, no markdown fence.
+
+            Examples (use these literal string values for "action"):
+              {{"action":"ACTION1"}}
+              {{"action":"ACTION3"}}
+              {{"action":"ACTION6","x":12,"y":34}}
+              {{"action":"RESET"}}
+
+            Action meanings:
+              "RESET"=start/restart.
+              "ACTION1", "ACTION2", "ACTION3", "ACTION4", "ACTION5", and
+              "ACTION7" are simple inputs. Many games use ACTION1/ACTION2/
+              ACTION3/ACTION4 as directional inputs and ACTION5 as an
+              interaction input, but you must infer each action's effect from
+              observations in the current game.
+              "ACTION6"=click/point at x,y with both coordinates in [0,63].
+
+            Rules:
+            - Only RESET when state is NOT_PLAYED or GAME_OVER.
+            - Pick from available_actions when given.
+            - Final output: a single JSON object. No markdown.
+
+            # FRAME
+            game_id: {game_id}
+            state: {state}
+            levels_completed: {levels}
+            win_levels: {win_levels}
+            available_actions: {available}
+
+            # GRID (hex)
+            {grid}
+            """
+        ).strip().format(
+            game_id=latest_frame.game_id,
+            state=latest_frame.state.name,
+            levels=latest_frame.levels_completed,
+            win_levels=latest_frame.win_levels,
+            available=self._action_names(latest_frame.available_actions),
+            grid=self._render_grid(latest_frame.frame),
+        )
+
+    def _action_names(self, actions: Optional[list[Any]]) -> list[str]:
+        # GameAction is a plain Enum (not IntEnum), so value->member must be
+        # done by scanning members rather than via GameAction(value).
+        out: list[str] = []
+        for a in actions or []:
+            if isinstance(a, GameAction):
+                out.append(a.name)
+                continue
+            try:
+                wanted = int(a)
+                matched = next((m for m in GameAction if m.value == wanted), None)
+                out.append(matched.name if matched else str(a))
+            except (TypeError, ValueError):
+                out.append(str(a))
+        return out
+
+    def _render_grid(self, grid_3d: Optional[list[list[list[int]]]]) -> str:
+        if not grid_3d:
+            return "(no grid)"
+        lines: list[str] = []
+        for i, plane in enumerate(grid_3d):
+            lines.append(f"Grid {i}:")
+            for row in plane:
+                lines.append("  " + "".join(f"{c:x}" for c in row))
+        return "\n".join(lines)
+
+    def cleanup(self, *args: Any, **kwargs: Any) -> None:
+        if self._cleanup and hasattr(self, "recorder") and not self.is_playback:
+            self.recorder.record(
+                {
+                    "openclaw_model": self.model,
+                    "openclaw_total_tokens": self.token_counter,
+                }
+            )
+        super().cleanup(*args, **kwargs)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import shutil
 
 import pytest
 
-from agents.structs import FrameData, GameState
+from arcengine import FrameData, GameState
 
 
 def get_test_recordings_dir():
@@ -47,7 +47,7 @@ def sample_frame():
         game_id="test-game",
         frame=[[[1, 2], [3, 4]]],
         state=GameState.NOT_FINISHED,
-        score=5,
+        levels_completed=5,
     )
 
 

--- a/tests/unit/test_openclaw_model_override.py
+++ b/tests/unit/test_openclaw_model_override.py
@@ -1,0 +1,100 @@
+"""Unit tests for the OPENCLAW_MODEL env var override.
+
+The override is intended to let callers compare provider models without
+editing ~/.openclaw/openclaw.json. It must be forwarded as the
+`x-openclaw-model` header on every chat completion request, and must
+collapse to "no header" when the env var is unset or empty (an empty
+header value would be invalid).
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from arcengine import FrameData, GameState
+
+from agents.templates.openclaw_agent import openclaw_agent as oc_module
+from agents.templates.openclaw_agent.openclaw_agent import OpenClaw
+
+
+def _make_response(content: str) -> MagicMock:
+    msg = MagicMock()
+    msg.content = content
+    choice = MagicMock()
+    choice.message = msg
+    resp = MagicMock()
+    resp.choices = [choice]
+    resp.usage = MagicMock(total_tokens=0)
+    return resp
+
+
+def _make_agent(monkeypatch: pytest.MonkeyPatch) -> tuple[OpenClaw, MagicMock]:
+    """Instantiate OpenClaw with the OpenAI client patched out."""
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = _make_response(
+        '{"action":"ACTION1"}'
+    )
+    monkeypatch.setattr(oc_module, "OpenAIClient", lambda **kw: mock_client)
+
+    agent = OpenClaw(
+        card_id="card-abc",
+        game_id="ls20-test",
+        agent_name="openclaw-test",
+        ROOT_URL="http://localhost",
+        record=False,
+        arc_env=MagicMock(),
+    )
+    return agent, mock_client
+
+
+def _frame() -> FrameData:
+    return FrameData(
+        game_id="ls20-test",
+        state=GameState.NOT_FINISHED,
+        available_actions=[1, 2, 3, 4, 5],
+        frame=[[[0] * 4 for _ in range(4)]],
+    )
+
+
+@pytest.mark.unit
+class TestModelOverride:
+    def test_header_persists_across_turns(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # __init__ reads the env var once and caches it on self; if anyone
+        # moves the read into choose_action this still passes only because
+        # the env is stable, so we also assert call_count to keep this honest.
+        monkeypatch.setenv("OPENCLAW_MODEL", "openai/gpt-5")
+        agent, client = _make_agent(monkeypatch)
+
+        for _ in range(3):
+            agent.choose_action([], _frame())
+
+        assert client.chat.completions.create.call_count == 3
+        for call in client.chat.completions.create.call_args_list:
+            assert call.kwargs["extra_headers"] == {"x-openclaw-model": "openai/gpt-5"}
+
+    def test_no_header_when_env_var_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("OPENCLAW_MODEL", raising=False)
+        agent, client = _make_agent(monkeypatch)
+
+        agent.choose_action([], _frame())
+
+        # `None` (not an empty dict) so the openai SDK omits the header
+        # entirely and the gateway falls back to its configured primary.
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] is None
+
+    def test_empty_env_var_treated_as_unset(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # OPENCLAW_MODEL="" must NOT send an empty x-openclaw-model header
+        # (which would be invalid). The `or None` in __init__ collapses
+        # empty strings to None; dropping that one character breaks this.
+        monkeypatch.setenv("OPENCLAW_MODEL", "")
+        agent, client = _make_agent(monkeypatch)
+
+        agent.choose_action([], _frame())
+
+        assert agent._model_override is None
+        assert client.chat.completions.create.call_args.kwargs["extra_headers"] is None

--- a/tests/unit/test_openclaw_parser.py
+++ b/tests/unit/test_openclaw_parser.py
@@ -1,0 +1,145 @@
+"""Unit tests for the OpenClaw agent's JSON-in-text action parser.
+
+The OpenClaw OpenAI-compat endpoint silently drops the OpenAI `tools` field
+for some providers, so this agent has the model reply with one JSON object
+on each turn. Parsing that JSON is the most failure-prone bit of the agent
+and is exercised here without spinning up a real gateway.
+"""
+
+import pytest
+from arcengine import GameAction
+
+from agents.templates.openclaw_agent.openclaw_agent import OpenClaw
+
+
+class _Msg:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+def _bare_agent() -> OpenClaw:
+    """Construct an OpenClaw instance without running __init__.
+
+    The parser is pure logic and doesn't depend on any agent state, so we
+    bypass __init__ (which would try to build an HTTP client and require
+    env vars) and call _parse_action directly.
+    """
+    return object.__new__(OpenClaw)  # type: ignore[return-value]
+
+
+@pytest.mark.unit
+class TestParseAction:
+    def test_canonical_name(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"action":"ACTION1"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION1
+
+    def test_lowercase_name(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"action":"action3"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION3
+
+    def test_reset(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"action":"RESET"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.RESET
+
+    def test_integer_string_id(self) -> None:
+        # Model sometimes emits {"action": "1"} instead of {"action": "ACTION1"}.
+        action = _bare_agent()._parse_action(_Msg('{"action":"1"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION1
+
+    def test_raw_integer_id(self) -> None:
+        # Or even {"action": 4}.
+        action = _bare_agent()._parse_action(_Msg('{"action":4}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION4
+
+    def test_action6_with_coords(self) -> None:
+        action = _bare_agent()._parse_action(
+            _Msg('{"action":"ACTION6","x":12,"y":34}'),
+            None,  # type: ignore[arg-type]
+        )
+        assert action is GameAction.ACTION6
+        assert action.action_data.x == 12  # type: ignore[union-attr]
+        assert action.action_data.y == 34  # type: ignore[union-attr]
+
+    def test_action6_with_string_coords(self) -> None:
+        # Models sometimes emit numbers as strings.
+        action = _bare_agent()._parse_action(
+            _Msg('{"action":"ACTION6","x":"7","y":"8"}'),
+            None,  # type: ignore[arg-type]
+        )
+        assert action is GameAction.ACTION6
+        assert action.action_data.x == 7  # type: ignore[union-attr]
+        assert action.action_data.y == 8  # type: ignore[union-attr]
+
+    def test_action6_missing_coords_falls_back_to_center(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"action":"ACTION6"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION6
+        # Coordinates default to the center of the 64x64 grid.
+        assert action.action_data.x == 32  # type: ignore[union-attr]
+        assert action.action_data.y == 32  # type: ignore[union-attr]
+
+    def test_markdown_fence_wrapper(self) -> None:
+        action = _bare_agent()._parse_action(
+            _Msg('```json\n{"action":"ACTION2"}\n```'),
+            None,  # type: ignore[arg-type]
+        )
+        assert action is GameAction.ACTION2
+
+    def test_leading_prose(self) -> None:
+        # The regex extractor finds the first {...} containing "action".
+        action = _bare_agent()._parse_action(
+            _Msg('Sure thing! Here is the action: {"action":"ACTION5"}'),
+            None,  # type: ignore[arg-type]
+        )
+        assert action is GameAction.ACTION5
+
+    def test_unknown_action_falls_back(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"action":"FLY"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION5
+
+    def test_out_of_range_integer_falls_back(self) -> None:
+        # Valid GameAction values are 0..7. 42 is not a member.
+        action = _bare_agent()._parse_action(_Msg('{"action":42}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION5
+
+    def test_missing_action_key_falls_back(self) -> None:
+        action = _bare_agent()._parse_action(_Msg('{"foo":"bar"}'), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION5
+
+    def test_unparseable_text_falls_back(self) -> None:
+        action = _bare_agent()._parse_action(_Msg("totally not json"), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION5
+
+    def test_empty_content_falls_back(self) -> None:
+        action = _bare_agent()._parse_action(_Msg(""), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION5
+
+
+@pytest.mark.unit
+class TestActionNames:
+    """Cover _action_names: it gets a list of available actions and must
+    normalize ints, strings, and GameAction members to canonical names."""
+
+    def test_handles_game_action_members(self) -> None:
+        names = _bare_agent()._action_names([GameAction.ACTION1, GameAction.ACTION3])
+        assert names == ["ACTION1", "ACTION3"]
+
+    def test_handles_integer_ids(self) -> None:
+        # ARC's FrameData.available_actions arrives as a list of ints.
+        names = _bare_agent()._action_names([1, 2, 3, 4])
+        assert names == ["ACTION1", "ACTION2", "ACTION3", "ACTION4"]
+
+    def test_handles_string_digits(self) -> None:
+        names = _bare_agent()._action_names(["1", "6"])
+        assert names == ["ACTION1", "ACTION6"]
+
+    def test_handles_unknown_values_gracefully(self) -> None:
+        names = _bare_agent()._action_names([99, "garbage"])
+        assert names == ["99", "garbage"]
+
+    def test_handles_none(self) -> None:
+        names = _bare_agent()._action_names(None)
+        assert names == []
+
+    def test_handles_empty(self) -> None:
+        names = _bare_agent()._action_names([])
+        assert names == []

--- a/tests/unit/test_openclaw_parser.py
+++ b/tests/unit/test_openclaw_parser.py
@@ -178,9 +178,23 @@ class TestExtractReasoning:
         assert out["alternatives_considered"][0] == "42"
         assert out["alternatives_considered"][1] == "x" * 200
 
-    def test_long_thought_truncated(self) -> None:
+    def test_thought_under_cap_passes_unchanged(self) -> None:
+        # Below 16 KB the model's thought passes through verbatim — the
+        # reviewer's trace-analysis use case relies on this.
         out = OpenClaw._extract_reasoning({"action": "ACTION1", "thought": "a" * 5000})
-        assert len(out["thought"]) == 1000
+        assert out["thought"] == "a" * 5000
+
+    def test_thought_over_cap_truncated_to_fit(self) -> None:
+        import json as _json
+        out = OpenClaw._extract_reasoning(
+            {"action": "ACTION1", "thought": "a" * 20000}
+        )
+        # The full JSON payload (not just thought) must fit under the cap.
+        size = len(_json.dumps(out, separators=(",", ":")).encode("utf-8"))
+        assert size <= 16 * 1024
+        # Thought is trimmed from the end, structure preserved.
+        assert out["thought"].startswith("a")
+        assert len(out["thought"]) < 20000
 
 
 @pytest.mark.unit

--- a/tests/unit/test_openclaw_parser.py
+++ b/tests/unit/test_openclaw_parser.py
@@ -115,6 +115,96 @@ class TestParseAction:
 
 
 @pytest.mark.unit
+class TestExtractReasoning:
+    """Cover _extract_reasoning: builds the four doc-listed fields with
+    consistent shape regardless of what the model returned."""
+
+    def test_happy_path(self) -> None:
+        blob = {
+            "action": "ACTION1",
+            "thought": "Player is below the door; move up.",
+            "confidence": 0.78,
+            "alternatives_considered": ["ACTION4 to test wall", "ACTION5 to wait"],
+        }
+        assert OpenClaw._extract_reasoning(blob) == {
+            "thought": "Player is below the door; move up.",
+            "confidence": 0.78,
+            "alternatives_considered": ["ACTION4 to test wall", "ACTION5 to wait"],
+            "reasoning_tokens": 0,
+        }
+
+    def test_missing_fields_get_defaults(self) -> None:
+        assert OpenClaw._extract_reasoning({"action": "ACTION1"}) == {
+            "thought": "(no thought provided)",
+            "confidence": 0.0,
+            "alternatives_considered": [],
+            "reasoning_tokens": 0,
+        }
+
+    def test_parse_failed_blob_marks_thought(self) -> None:
+        # blob=None means the parser couldn't extract any JSON at all.
+        out = OpenClaw._extract_reasoning(None)
+        assert out["thought"] == "(parse failed)"
+
+    def test_confidence_above_one_clamped(self) -> None:
+        out = OpenClaw._extract_reasoning({"action": "ACTION1", "confidence": 1.7})
+        assert out["confidence"] == 1.0
+
+    def test_confidence_below_zero_clamped(self) -> None:
+        out = OpenClaw._extract_reasoning({"action": "ACTION1", "confidence": -0.3})
+        assert out["confidence"] == 0.0
+
+    def test_confidence_non_numeric_falls_back_to_zero(self) -> None:
+        out = OpenClaw._extract_reasoning({"action": "ACTION1", "confidence": "high"})
+        assert out["confidence"] == 0.0
+
+    def test_alternatives_non_list_falls_back_to_empty(self) -> None:
+        out = OpenClaw._extract_reasoning(
+            {"action": "ACTION1", "alternatives_considered": "not a list"}
+        )
+        assert out["alternatives_considered"] == []
+
+    def test_alternatives_truncated_to_five_items(self) -> None:
+        out = OpenClaw._extract_reasoning(
+            {"action": "ACTION1", "alternatives_considered": list("abcdefgh")}
+        )
+        assert out["alternatives_considered"] == ["a", "b", "c", "d", "e"]
+
+    def test_alternatives_items_coerced_to_str_and_truncated(self) -> None:
+        long = "x" * 500
+        out = OpenClaw._extract_reasoning(
+            {"action": "ACTION1", "alternatives_considered": [42, long]}
+        )
+        assert out["alternatives_considered"][0] == "42"
+        assert out["alternatives_considered"][1] == "x" * 200
+
+    def test_long_thought_truncated(self) -> None:
+        out = OpenClaw._extract_reasoning({"action": "ACTION1", "thought": "a" * 5000})
+        assert len(out["thought"]) == 1000
+
+
+@pytest.mark.unit
+class TestParseActionWithReasoningBlob:
+    """The regex extractor must handle JSON with nested arrays
+    (e.g. alternatives_considered) when buried in prose or fences."""
+
+    def test_blob_with_alternatives_array(self) -> None:
+        text = '{"action":"ACTION2","thought":"go down","confidence":0.5,"alternatives_considered":["a","b"]}'
+        action = _bare_agent()._parse_action(_Msg(text), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION2
+
+    def test_blob_with_alternatives_array_inside_prose(self) -> None:
+        text = 'Here you go: {"action":"ACTION3","alternatives_considered":["x","y","z"]}'
+        action = _bare_agent()._parse_action(_Msg(text), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION3
+
+    def test_markdown_fence_with_array(self) -> None:
+        text = '```json\n{"action":"ACTION1","alternatives_considered":["a"]}\n```'
+        action = _bare_agent()._parse_action(_Msg(text), None)  # type: ignore[arg-type]
+        assert action is GameAction.ACTION1
+
+
+@pytest.mark.unit
 class TestActionNames:
     """Cover _action_names: it gets a list of available actions and must
     normalize ints, strings, and GameAction members to canonical names."""

--- a/tests/unit/test_openclaw_parser.py
+++ b/tests/unit/test_openclaw_parser.py
@@ -186,9 +186,8 @@ class TestExtractReasoning:
 
     def test_thought_over_cap_truncated_to_fit(self) -> None:
         import json as _json
-        out = OpenClaw._extract_reasoning(
-            {"action": "ACTION1", "thought": "a" * 20000}
-        )
+
+        out = OpenClaw._extract_reasoning({"action": "ACTION1", "thought": "a" * 20000})
         # The full JSON payload (not just thought) must fit under the cap.
         size = len(_json.dumps(out, separators=(",", ":")).encode("utf-8"))
         assert size <= 16 * 1024
@@ -208,7 +207,9 @@ class TestParseActionWithReasoningBlob:
         assert action is GameAction.ACTION2
 
     def test_blob_with_alternatives_array_inside_prose(self) -> None:
-        text = 'Here you go: {"action":"ACTION3","alternatives_considered":["x","y","z"]}'
+        text = (
+            'Here you go: {"action":"ACTION3","alternatives_considered":["x","y","z"]}'
+        )
         action = _bare_agent()._parse_action(_Msg(text), None)  # type: ignore[arg-type]
         assert action is GameAction.ACTION3
 


### PR DESCRIPTION
Add example OpenClaw run

Couple notes:
- Requires OpenClaw running separately, I added a docker compose file for hosting
- I left the default OpenClaw prompt, this includes a bunch of extra stuff like the SOUL.md and BOOTSTRAP.md and so on. Not sure how much of that I should remove
- Prompt/context is huge given the above
- The board is given via a text representation, not an image
- OpenClaw communicates by outputting JSON, the most idiomatic approach would be a skill which interacted with the board via a CLI
- Tested using Sonnet 4.6, it wasn't able to get through the first level, not sure if that is expected
- I haven't implemented the reasoning APIs yet
- Code was written with Claude and Codex, I reviewed it myself before creating PR