### PR TITLE
Fix off-by-one error for MAX_ACTIONS

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -71,7 +71,7 @@ class Agent(ABC):
         self.timer = time.time()
         while (
             not self.is_done(self.frames, self.frames[-1])
-            and self.action_counter <= self.MAX_ACTIONS
+            and self.action_counter < self.MAX_ACTIONS
         ):
             action = self.choose_action(
                 self.frames,
@@ -82,7 +82,7 @@ class Agent(ABC):
             if frame := self.take_action(action):
                 self.append_frame(frame)
                 logger.info(
-                    f"{self.game_id} - {action.name}: count {self.action_counter}, levels completed {frame.levels_completed}, avg fps {self.fps})"
+                    f"{self.game_id} - {action.name}: count {self.action_counter + 1}, levels completed {frame.levels_completed}, avg fps {self.fps})"
                 )
             self.action_counter += 1
 


### PR DESCRIPTION
I believe there's an off-by-one error with the MAX_ACTIONS logic.

Specifically, when you run:

```
uv run main.py --agent=random --game=ls20
```

It will keep performing random actions, outputting in the logs:

```
2026-07-03 11:53:47,958 | INFO | ls20-9607627b - ACTION4: count 0, levels completed 0, avg fps 0.0)
2026-07-03 11:53:48,264 | INFO | ls20-9607627b - ACTION5: count 1, levels completed 0, avg fps 2.33)
2026-07-03 11:53:48,581 | INFO | ls20-9607627b - ACTION2: count 2, levels completed 0, avg fps 2.67)
...
2026-07-03 11:54:06,851 | INFO | ls20-9607627b - ACTION3: count 78, levels completed 0, avg fps 4.1)
2026-07-03 11:54:07,049 | INFO | ls20-9607627b - ACTION7: count 79, levels completed 0, avg fps 4.11)
2026-07-03 11:54:07,178 | INFO | ls20-9607627b - ACTION5: count 80, levels completed 0, avg fps 4.14)
...
2026-07-03 11:54:07,178 | INFO | Exiting: agent reached MAX_ACTIONS of 80, took 19.34 seconds (4.19 average fps)
```

And in the scorecard report:

```
  "total_environments_completed": 0,
  "total_environments": 1,
  "total_levels_completed": 0,
  "total_levels": 7,
  "total_actions": 81
```

Note, however, in the code, `MAX_ACTIONS` is set to 80:

```
MAX_ACTIONS: int = 80
```

So why is `total_actions` set to 81 instead of 80?

Here's the relevant code:

```python
action_counter: int = 0
...
while (
    not self.is_done(self.frames, self.frames[-1])
    and self.action_counter <= self.MAX_ACTIONS
):
    action = self.choose_action(...)
    if frame := self.take_action(action):
        ...
        logger.info(f"... count {self.action_counter} ...")
    self.action_counter += 1
```

Notice we start the counter at 0, and then continue until `self.action_counter <= self.MAX_ACTIONS`. However, if MAX_ACTIONS is 80, this will loop 81 times (0 through 80 inclusive).

To ensure the agent only ever performs 80 actions, we can change that `<=` to just `<`, which this PR takes care of.

Similarly, the logs would be clearer if they were 1-indexed instead of 0. The first action should reflect `count 1` and so on up to `count 80`. This PR makes that change too.

With these changes in place, the new output for the initial command becomes:

```
2026-07-03 12:22:14,325 | INFO | ls20-9607627b - ACTION1: count 1, levels completed 0, avg fps 0.0)
2026-07-03 12:22:14,635 | INFO | ls20-9607627b - ACTION3: count 2, levels completed 0, avg fps 2.33)
2026-07-03 12:22:14,943 | INFO | ls20-9607627b - ACTION3: count 3, levels completed 0, avg fps 2.7)
...
2026-07-03 12:22:33,408 | INFO | ls20-9607627b - ACTION1: count 78, levels completed 0, avg fps 4.01)
2026-07-03 12:22:33,678 | INFO | ls20-9607627b - ACTION4: count 79, levels completed 0, avg fps 4.0)
2026-07-03 12:22:33,794 | INFO | ls20-9607627b - ACTION6: count 80, levels completed 0, avg fps 4.03)
...
2026-07-03 12:22:33,795 | INFO | Exiting: agent reached MAX_ACTIONS of 80, took 19.59 seconds (4.08 average fps)
```

And now the scorecard JSON correctly reflects 80 actions:

```
  "total_environments_completed": 0,
  "total_environments": 1,
  "total_levels_completed": 0,
  "total_levels": 7,
  "total_actions": 80
```

The log change isn't strictly necessary (0-79 would also be correct after the loop fix), but with 1-indexing the final log line, `MAX_ACTIONS`, and the scorecard's total_actions all agree at 80, so any future off-by-one would be immediately visible.