### PR TITLE
Preserve action_input when converting raw frames (fixes #91)

### DIFF
--- a/agents/agent.py
+++ b/agents/agent.py
@@ -153,6 +153,7 @@ class Agent(ABC):
             guid=raw.guid,
             full_reset=raw.full_reset,
             available_actions=raw.available_actions,
+            action_input=raw.action_input,
         )
         return out
 


### PR DESCRIPTION
﻿Fixes #91.

`_convert_raw_frame_data` builds a fresh `FrameData` and never copies `action_input`, so the field falls back to its pydantic default `ActionInput(id=RESET, data={})` on every frame. @ianozsvald diagnosed this in #91 and wrote this one-line fix; this PR is his patch, opened with the extra evidence below.

### Three consequences

**1. Recordings lose which action was taken.** Every frame in `.recording.jsonl` reports `RESET`, and `action_data` — e.g. the `x`/`y` of an `ACTION6` click — is gone with it.

**2. `Playback` replays the wrong actions.** `Playback.choose_action` reconstructs each action from exactly this field, so any recording replays as a run of `RESET`. `filter_actions` still returns the right record *count*, because every record does contain an `action_input` key — so the failure is silent: a plausible-length replay of the wrong actions, with no warning.

**3. The model is misinformed at runtime.** On the default `MODEL_REQUIRES_TOOLS = False` path, `llm_agents.py:125` labels the function-response message with `latest_frame.action_input.id.name`, which is therefore always `RESET`. `build_func_resp_prompt` carries only state/score/frame, so that field is the sole place the action is identified — and it never matches the `function_call` it answers. The assistant's own preceding message does carry the correct name, so the information isn't absent; the transcript contradicts itself on every step after the first.

### Verification

Both directions, against the real `LLM` policy with a stubbed client and a deterministic environment that stamps `action_input` the way `arcengine/base_game.py:246` does:

```
without the fix — function-response names: RESET, RESET, RESET, RESET, ...
with the fix:                              RESET, ACTION1, ACTION6, ACTION2, ...
```

### One caveat worth a release note

**This changes agent behaviour**, because it changes the prompt the model sees. That's the point — but it means scores from before and after aren't directly comparable, which you may want to flag.

The `MODEL_REQUIRES_TOOLS = True` path is unaffected; it uses `tool_call_id` and has no `name` field.

Happy to add a regression test that round-trips a recorded session through `Playback` and asserts the same action sequence comes back, if you'd like it in the same PR.
