### PR TITLE
Default MODEL_REQUIRES_TOOLS to True (the llm template 400s on current OpenAI models)

### DIFF
--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -19,7 +19,11 @@ class LLM(Agent):
     MAX_ACTIONS: int = 80
     DO_OBSERVATION: bool = True
     REASONING_EFFORT: Optional[str] = None
-    MODEL_REQUIRES_TOOLS: bool = False
+    # Current OpenAI models reject the legacy function-calling format
+    # (`function_call` + `{"role": "function"}`) outright, so the legacy path
+    # can no longer be the default. Set to False only for a provider that still
+    # requires the old format.
+    MODEL_REQUIRES_TOOLS: bool = True
 
     MESSAGE_LIMIT: int = 10
     MODEL: str = "gpt-4o-mini"


### PR DESCRIPTION
﻿### The problem

`main.py -a llm` — the primary entrypoint in the README — cannot talk to current OpenAI models.

With `MODEL_REQUIRES_TOOLS = False`, `choose_action` builds the deprecated function-calling shape: `function_call` on the assistant message and `{"role": "function", "name": ...}` for the response. Current models reject that outright, on the **second** model call:

```
Invalid value: 'function'. Supported values are: 'assistant', 'system', 'developer', and 'user'.
  param: input[2]
  code:  invalid_value
```

Reproduced 2026-08-02 against `openai/gpt-5.6-terra`; the OpenAI and Azure providers both returned the same 400. The run dies before the agent takes a single non-RESET action, and nothing in the error suggests that one class attribute fixes it.

### Why this is the right fix rather than a docs note

The modern path — `tools` + `{"role": "tool"}` + `tool_call_id` — is **already implemented in this same file**, and your own newer templates already opt into it:

```python
class ReasoningLLM(LLM, Agent):
    MODEL_REQUIRES_TOOLS = True
    MODEL = "o4-mini"
```

```python
class GuidedLLM(...):
    MODEL = "o3"
    MODEL_REQUIRES_TOOLS = True
```

So the working configuration is already the one you use for anything recent. This just makes the base class agree, so the default template works out of the box instead of failing for a reason the traceback doesn't explain.

Anything still needing the legacy shape can opt back in with `MODEL_REQUIRES_TOOLS = False` on its subclass.

### Alternatives, if you'd rather not move a default

Happy to rework this as either of:

- a targeted `except openai.BadRequestError` that detects the `'function'` role rejection and re-raises with "set `MODEL_REQUIRES_TOOLS = True` for this model", or
- a README note only.

I'd argue for the default flip, since the current state means the documented quickstart is broken against the models most people will reach for — but it's your call and I'll happily send whichever you prefer.

Related: #91 / #96 (that one is on the `MODEL_REQUIRES_TOOLS = False` path specifically, and is unaffected by this change).
