### PR TITLE
Coerce integer-valued tool arguments that arrive as strings (runs are truncated mid-game otherwise)

### DIFF
--- a/agents/templates/llm_agents.py
+++ b/agents/templates/llm_agents.py
@@ -13,6 +13,33 @@ from ..agent import Agent
 logger = logging.getLogger()
 
 
+def _coerce_numeric_args(data: Any) -> Any:
+    """Accept integer-valued tool arguments that arrive as strings.
+
+    `GameAction.set_data` validates through pydantic, so an ACTION6 whose
+    `x`/`y` arrive as strings raises `ValidationError` out of `choose_action`
+    and terminates the run. Models emit quoted numbers often enough that this
+    silently truncates some agents' runs and not others.
+
+    Deliberately narrow: only strings that are exactly an integer after
+    stripping whitespace and quote characters are converted. Everything else
+    is passed through untouched, so a genuinely malformed argument still fails
+    loudly rather than being quietly reinterpreted.
+    """
+    if not isinstance(data, dict):
+        return data
+    coerced = {}
+    for key, value in data.items():
+        if isinstance(value, str):
+            try:
+                coerced[key] = int(value.strip().strip("\"'").strip())
+                continue
+            except (TypeError, ValueError):
+                pass
+        coerced[key] = value
+    return coerced
+
+
 class LLM(Agent):
     """An agent that uses a base LLM model to play games."""
 
@@ -217,7 +244,7 @@ class LLM(Agent):
             data = {}
 
         action = GameAction.from_name(action_id)
-        action.set_data(data)
+        action.set_data(_coerce_numeric_args(data))
         return action
 
     def track_tokens(self, tokens: int, message: str = "") -> None:


### PR DESCRIPTION
﻿### The problem

`GameAction.set_data` validates through pydantic, so an `ACTION6` whose `x`/`y` arrive as strings raises `ValidationError` **out of `choose_action`** and terminates the run.

Observed 2026-08-02 with `anthropic/claude-sonnet-5` on `ls20`, at action **56 of 80**:

```
ValidationError: 2 validation errors for ComplexAction
x
  Input should be a valid integer, unable to parse string as an integer
  [type=int_parsing, input_value='"35"', input_type=str]
y
  Input should be a valid integer
```

The agent was doing well at that point. From its own observations two actions earlier:

> *"Each ACTION4 press moves it exactly one column, so I'll need several more presses to fully align it under the target markers."*

It had worked out the mechanic and was executing a plan. It lost 30% of its budget to a quoting detail.

### Why this is more than robustness

Without coercion, **a model that formats tool arguments imperfectly gets a truncated run, and a model that formats them cleanly gets a full one.** Any comparison across models then partly measures JSON-formatting discipline rather than the capability under study — and nothing in the resulting scores reveals that it happened. The run just ends early and scores lower.

That seems worth avoiding in a benchmark harness specifically.

### The change

One small helper, applied at the single point where parsed arguments meet `set_data`. Deliberately narrow — only strings that are *exactly* an integer after stripping whitespace and quote characters are converted:

| input | output |
|---|---|
| `{'x': '"35"', 'y': '20'}` | `{'x': 35, 'y': 20}` |
| `{'x': 35}` | `{'x': 35}` (unchanged) |
| `{'x': ' 7 ', 'game_id': 'ls20'}` | `{'x': 7, 'game_id': 'ls20'}` |
| `{'x': 'left'}` | `{'x': 'left'}` (unchanged) |
| `{'x': '3.5'}` | `{'x': '3.5'}` (unchanged) |

Non-integer strings pass through untouched, so a genuinely malformed argument still fails loudly rather than being quietly reinterpreted as something the model did not say.

Happy to add unit tests for the table above if you'd like them in this PR, or to narrow it further to only the `x`/`y` keys if you'd prefer a tighter blast radius.
