### PR TITLE
Serialise Recorder.record with a lock (fixes the intermittent test_concurrent_recording failure)

### DIFF
--- a/agents/recorder.py
+++ b/agents/recorder.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import uuid
 from datetime import datetime, timezone
 from typing import Any, Optional
@@ -27,6 +28,10 @@ class Recorder:
                 f"{self.prefix}.{self.guid}{RECORDING_SUFFIX}",
             )
         )
+        # Serialises concurrent `record` calls. `json.dump` writes in several
+        # small chunks, so two threads appending to one file can interleave
+        # mid-line and lose or corrupt an event.
+        self._write_lock = threading.Lock()
         # Create directory once during initialization
         if recordings_dir:
             os.makedirs(recordings_dir, exist_ok=True)
@@ -40,9 +45,12 @@ class Recorder:
         event["timestamp"] = datetime.now(timezone.utc).isoformat()
         event["data"] = data
 
-        with open(self.filename, "a", encoding="utf-8") as f:
-            json.dump(event, f)
-            f.write("\n")
+        # One serialised string, one write, under a lock: an interleaved
+        # `json.dump` could drop or corrupt an event under concurrency.
+        line = json.dumps(event) + "\n"
+        with self._write_lock:
+            with open(self.filename, "a", encoding="utf-8") as f:
+                f.write(line)
 
     def get(self) -> list[dict[str, Any]]:
         """


### PR DESCRIPTION
﻿### The problem

`Recorder.record` writes with:

```python
with open(self.filename, "a", encoding="utf-8") as f:
    json.dump(event, f)
    f.write("\n")
```

`json.dump` emits several small writes rather than one, so two threads appending through the same `Recorder` can interleave mid-line and lose or corrupt an event.

**This is already visible in your own test suite.** `tests/unit/test_recorder.py::TestRecorderErrorHandling::test_concurrent_recording` fails intermittently, typically with `assert 4 == 5` — one of five events gone.

### Measured, not assumed

| | result |
|---|---|
| current `main`, 20 runs | **19 passed, 1 failed** |
| with this change, 30 runs | **30 passed, 0 failed** |

### The change

Serialise the event to a single string, then perform one write under a `threading.Lock`.

### Severity

Low in normal use — `Swarm` gives each agent its own `Recorder` and its own file, so nothing in the shipped paths shares a writer. But it is a flaky test in CI, and the race is real for anything that does share a `Recorder`.

Happy to drop this if you'd rather fix the test than the class, though the test looks like it is describing the intended contract.
